### PR TITLE
Frontend: implement kanban board and card workflow

### DIFF
--- a/SmartTasksAPI/smarttasks-frontend/src/app/app.routes.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/app.routes.ts
@@ -2,11 +2,17 @@ import { Routes } from '@angular/router';
 import { Login } from './pages/login/login';
 import { Register } from './pages/register/register';
 import { Boards } from './pages/boards/boards';
+import { BoardDetails } from './pages/board-details/board-details';
+import { CardDetails } from './pages/card-details/card-details';
+import { CreateCard } from './pages/create-card/create-card';
 
 export const routes: Routes = [
     { path: '', redirectTo: 'login', pathMatch: 'full' },
     { path: 'login', component: Login },
     { path: 'register', component: Register },
     { path: 'boards', component: Boards },
+    { path: 'boards/:id', component: BoardDetails },
+    { path: 'boards/:boardId/cards/new', component: CreateCard },
+    { path: 'boards/:boardId/cards/:cardId', component: CardDetails },
     { path: '**', redirectTo: 'login' }
 ];

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/models/board-list.model.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/models/board-list.model.ts
@@ -1,0 +1,10 @@
+import { CardItemModel } from './card-item.model';
+
+export interface BoardListModel {
+    id: string;
+    boardId: string;
+    name: string;
+    position: number;
+    createdAtUtc?: string;
+    cards?: CardItemModel[];
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/models/board.model.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/models/board.model.ts
@@ -1,7 +1,25 @@
+import { BoardListModel } from './board-list.model';
+
+export interface BoardMemberUserModel {
+    id: string;
+    fullName: string;
+    email: string;
+}
+
+export interface BoardMemberModel {
+    boardId: string;
+    userId: string;
+    role: number;
+    addedAtUtc: string;
+    user?: BoardMemberUserModel | null;
+}
+
 export interface BoardModel {
     id: string;
     name: string;
     description?: string | null;
-    ownerId?: string;
+    ownerId: string;
     createdAtUtc?: string;
+    members?: BoardMemberModel[];
+    lists?: BoardListModel[];
 }

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/models/card-comment.model.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/models/card-comment.model.ts
@@ -1,0 +1,14 @@
+export interface CardCommentAuthorModel {
+    id: string;
+    fullName: string;
+    email: string;
+}
+
+export interface CardCommentModel {
+    id: string;
+    cardId: string;
+    authorId: string;
+    message: string;
+    createdAtUtc: string;
+    author?: CardCommentAuthorModel | null;
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/models/card-item.model.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/models/card-item.model.ts
@@ -1,0 +1,26 @@
+import { CardCommentModel } from './card-comment.model';
+
+export interface CardAssignmentUserModel {
+    id: string;
+    fullName: string;
+    email: string;
+}
+
+export interface CardAssignmentModel {
+    cardId: string;
+    userId: string;
+    assignedAtUtc: string;
+    user?: CardAssignmentUserModel | null;
+}
+
+export interface CardItemModel {
+    id: string;
+    listId: string;
+    title: string;
+    description?: string | null;
+    position: number;
+    dueDateUtc?: string | null;
+    createdAtUtc?: string;
+    assignments?: CardAssignmentModel[];
+    comments?: CardCommentModel[];
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/board-access.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/board-access.ts
@@ -1,0 +1,53 @@
+import { Injectable } from '@angular/core';
+import { Observable, of, switchMap } from 'rxjs';
+
+import { Auth } from './auth';
+import { Users, BackendUser } from './users';
+import { BoardModel } from '../models/board.model';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class BoardAccess {
+    constructor(
+        private authService: Auth,
+        private usersService: Users
+    ) { }
+
+    getCurrentBackendUser(): Observable<BackendUser | null> {
+        const currentUser = this.authService.getCurrentUser();
+
+        if (!currentUser) {
+            return of(null);
+        }
+
+        return this.usersService.getUsers().pipe(
+            switchMap(users => {
+                const existingUser = users.find(
+                    u => u.email.trim().toLowerCase() === currentUser.email.trim().toLowerCase()
+                );
+
+                if (existingUser) {
+                    return of(existingUser);
+                }
+
+                return this.usersService.createUser({
+                    fullName: currentUser.username,
+                    email: currentUser.email
+                });
+            })
+        );
+    }
+
+    canAccessBoard(board: BoardModel | null | undefined, userId: string | null | undefined): boolean {
+        if (!board || !userId) {
+            return false;
+        }
+
+        if (board.ownerId === userId) {
+            return true;
+        }
+
+        return (board.members ?? []).some(member => member.userId === userId);
+    }
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/boards.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/boards.ts
@@ -14,4 +14,35 @@ export class Boards {
   getBoards(): Observable<BoardModel[]> {
     return this.http.get<BoardModel[]>(this.apiUrl);
   }
+
+  getBoardById(boardId: string): Observable<BoardModel> {
+    return this.http.get<BoardModel>(`${this.apiUrl}/${boardId}`);
+  }
+
+  createBoard(payload: {
+    name: string;
+    description?: string | null;
+    ownerId: string;
+  }): Observable<BoardModel> {
+    return this.http.post<BoardModel>(this.apiUrl, payload);
+  }
+
+  updateBoard(boardId: string, payload: {
+    name: string;
+    description?: string | null;
+  }): Observable<void> {
+    return this.http.put<void>(`${this.apiUrl}/${boardId}`, payload);
+  }
+
+  deleteBoard(boardId: string): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${boardId}`);
+  }
+
+  addMember(boardId: string, payload: { userId: string }): Observable<void> {
+    return this.http.post<void>(`${this.apiUrl}/${boardId}/members`, payload);
+  }
+
+  removeMember(boardId: string, userId: string): Observable<void> {
+    return this.http.delete<void>(`${this.apiUrl}/${boardId}/members/${userId}`);
+  }
 }

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/cards.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/cards.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Cards } from './cards';
+
+describe('Cards', () => {
+  let service: Cards;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(Cards);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/cards.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/cards.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { CardItemModel } from '../models/card-item.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class Cards {
+  private readonly baseUrl = 'http://localhost:5065/api';
+
+  constructor(private http: HttpClient) { }
+
+  getCardsByList(listId: string): Observable<CardItemModel[]> {
+    return this.http.get<CardItemModel[]>(`${this.baseUrl}/lists/${listId}/cards`);
+  }
+
+  getCardById(cardId: string): Observable<CardItemModel> {
+    return this.http.get<CardItemModel>(`${this.baseUrl}/cards/${cardId}`);
+  }
+
+  createCard(listId: string, payload: {
+    title: string;
+    description?: string | null;
+    dueDateUtc?: string | null;
+  }): Observable<CardItemModel> {
+    return this.http.post<CardItemModel>(`${this.baseUrl}/lists/${listId}/cards`, payload);
+  }
+
+  updateCard(cardId: string, payload: {
+    title: string;
+    description?: string | null;
+    position: number;
+    dueDateUtc?: string | null;
+  }): Observable<void> {
+    return this.http.put<void>(`${this.baseUrl}/cards/${cardId}`, payload);
+  }
+
+  moveCard(cardId: string, payload: {
+    TargetListId: string;
+    TargetPosition: number;
+  }): Observable<void> {
+    return this.http.patch<void>(`${this.baseUrl}/cards/${cardId}/move`, payload);
+  }
+
+  assignUser(cardId: string, userId: string): Observable<void> {
+    return this.http.post<void>(`${this.baseUrl}/cards/${cardId}/assignments/${userId}`, {});
+  }
+
+  unassignUser(cardId: string, userId: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/cards/${cardId}/assignments/${userId}`);
+  }
+
+  deleteCard(cardId: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/cards/${cardId}`);
+  }
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/comments.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/comments.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Comments } from './comments';
+
+describe('Comments', () => {
+  let service: Comments;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(Comments);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/comments.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/comments.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { CardCommentModel } from '../models/card-comment.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class Comments {
+  private readonly baseUrl = 'http://localhost:5065/api';
+
+  constructor(private http: HttpClient) { }
+
+  getCommentsByCard(cardId: string): Observable<CardCommentModel[]> {
+    return this.http.get<CardCommentModel[]>(`${this.baseUrl}/cards/${cardId}/comments`);
+  }
+
+  createComment(cardId: string, payload: {
+    authorId: string;
+    message: string;
+  }): Observable<CardCommentModel> {
+    return this.http.post<CardCommentModel>(`${this.baseUrl}/cards/${cardId}/comments`, payload);
+  }
+
+  deleteComment(commentId: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/comments/${commentId}`);
+  }
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/lists.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/lists.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Lists } from './lists';
+
+describe('Lists', () => {
+  let service: Lists;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(Lists);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/lists.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/lists.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { BoardListModel } from '../models/board-list.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class Lists {
+  private readonly baseUrl = 'http://localhost:5065/api';
+
+  constructor(private http: HttpClient) { }
+
+  createList(boardId: string, name: string): Observable<BoardListModel> {
+    return this.http.post<BoardListModel>(`${this.baseUrl}/boards/${boardId}/lists`, {
+      name
+    });
+  }
+
+  getListById(listId: string): Observable<BoardListModel> {
+    return this.http.get<BoardListModel>(`${this.baseUrl}/lists/${listId}`);
+  }
+
+  updateList(listId: string, payload: { name: string; position: number }): Observable<void> {
+    return this.http.put<void>(`${this.baseUrl}/lists/${listId}`, payload);
+  }
+
+  deleteList(listId: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/lists/${listId}`);
+  }
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/users.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/users.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { Users } from './users';
+
+describe('Users', () => {
+  let service: Users;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(Users);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/users.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/users.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface BackendUser {
+  id: string;
+  fullName: string;
+  email: string;
+  createdAtUtc?: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class Users {
+  private readonly apiUrl = 'http://localhost:5065/api/users';
+
+  constructor(private http: HttpClient) { }
+
+  getUsers(): Observable<BackendUser[]> {
+    return this.http.get<BackendUser[]>(this.apiUrl);
+  }
+
+  createUser(payload: { fullName: string; email: string }): Observable<BackendUser> {
+    return this.http.post<BackendUser>(this.apiUrl, payload);
+  }
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/board-details/board-details.html
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/board-details/board-details.html
@@ -1,0 +1,118 @@
+<div class="board-details-page">
+    <div class="board-details-container">
+        <div class="top-bar">
+            <a routerLink="/boards" class="back-link">← Back to boards</a>
+        </div>
+
+        @if (isLoading) {
+        <div class="state-box">Loading board...</div>
+        }
+
+        @if (!isLoading && errorMessage) {
+        <div class="state-box error-box">{{ errorMessage }}</div>
+        }
+
+        @if (!isLoading && board) {
+        <div class="board-header">
+            <div>
+                <h1>{{ board.name }}</h1>
+                <p>{{ board.description || 'No description available.' }}</p>
+            </div>
+
+            <button type="button" (click)="goToCreateCard()">New card</button>
+        </div>
+
+        <div class="members-box">
+            <h2>Board members</h2>
+
+            <div class="members-list">
+                @for (member of board.members ?? []; track member.userId) {
+                <div class="member-chip">
+                    <div class="member-info">
+                        <strong>{{ getMemberName(member) }}</strong>
+                        @if (getMemberEmail(member)) {
+                        <span>{{ getMemberEmail(member) }}</span>
+                        }
+                    </div>
+
+                    @if (isOwnerMember(member)) {
+                    <span class="owner-badge">Owner</span>
+                    } @else {
+                    <button type="button" class="remove-member-btn" (click)="removeMember(member.userId)"
+                        [disabled]="removingMemberId === member.userId">
+                        {{ removingMemberId === member.userId ? 'Removing...' : 'Remove' }}
+                    </button>
+                    }
+                </div>
+                }
+            </div>
+
+            <div class="add-member-box">
+                <select [(ngModel)]="selectedMemberId">
+                    <option value="">Select user</option>
+                    @for (user of availableUsers; track user.id) {
+                    <option [value]="user.id">{{ user.fullName }} — {{ user.email }}</option>
+                    }
+                </select>
+
+                <button type="button" (click)="addMember()" [disabled]="addingMember">
+                    {{ addingMember ? 'Adding...' : 'Add member' }}
+                </button>
+            </div>
+
+            @if (memberError) {
+            <p class="form-error">{{ memberError }}</p>
+            }
+        </div>
+
+        <div class="kanban-wrapper">
+            @for (column of columns; track column.list.id) {
+            <div class="kanban-column">
+                <div class="column-header">
+                    <h2>{{ column.list.name }}</h2>
+                    <span class="card-count">{{ column.cards.length }}</span>
+                </div>
+
+                <p class="column-description">
+                    {{ getColumnDescription(column.list.name) }}
+                </p>
+
+                <div class="column-cards">
+                    @if (column.cards.length === 0) {
+                    <div class="empty-column">No cards</div>
+                    }
+
+                    @for (card of column.cards; track card.id) {
+                    <div class="kanban-card" (click)="openCard(card.id)">
+                        <h3>{{ card.title }}</h3>
+
+                        <div class="card-meta">
+                            <span class="due-badge" [ngClass]="'due-' + getDueDateStatus(card)">
+                                @if (card.dueDateUtc) {
+                                {{ card.dueDateUtc | date:'mediumDate' }}
+                                } @else {
+                                No due date
+                                }
+                            </span>
+                        </div>
+
+                        @if (hasAssignees(card)) {
+                        <div class="card-assignees">
+                            @for (name of getVisibleAssigneeNames(card); track name) {
+                            <span class="assignee-badge">{{ name }}</span>
+                            }
+
+                            @if (getRemainingAssigneeCount(card) > 0) {
+                            <span class="assignee-more">+{{ getRemainingAssigneeCount(card) }}</span>
+                            }
+                        </div>
+                        }
+                    </div>
+                    }
+                </div>
+            </div>
+            }
+        </div>
+        }
+    </div>
+</div>

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/board-details/board-details.scss
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/board-details/board-details.scss
@@ -1,0 +1,293 @@
+.board-details-page {
+    min-height: 100vh;
+    padding: 14px;
+}
+
+.board-details-container {
+    max-width: 1320px;
+    margin: 0 auto;
+}
+
+.top-bar {
+    margin-bottom: 12px;
+}
+
+.back-link {
+    font-weight: 600;
+    font-size: 13px;
+}
+
+.board-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    margin-bottom: 14px;
+}
+
+.board-header h1 {
+    margin-bottom: 6px;
+    font-size: 24px;
+    line-height: 1.05;
+    color: var(--text);
+}
+
+.board-header p {
+    color: var(--muted);
+    font-size: 13px;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.state-box {
+    background: var(--panel);
+    color: var(--text);
+    border-radius: 10px;
+    padding: 10px 12px;
+}
+
+.error-box {
+    color: var(--danger);
+    background: rgba(239, 68, 68, 0.16);
+}
+
+.kanban-wrapper {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(220px, 1fr));
+    gap: 12px;
+    align-items: start;
+    overflow-x: auto;
+    padding-bottom: 6px;
+}
+
+.kanban-column {
+    background: var(--panel-soft);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 10px;
+    min-height: 420px;
+    box-shadow: var(--shadow);
+}
+
+.column-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    margin-bottom: 6px;
+}
+
+.column-header h2 {
+    font-size: 16px;
+    line-height: 1.1;
+}
+
+.card-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 22px;
+    height: 22px;
+    padding: 0 6px;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.18);
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 700;
+}
+
+.column-description {
+    color: var(--muted);
+    font-size: 12px;
+    margin-bottom: 10px;
+}
+
+.column-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.empty-column {
+    background: var(--panel);
+    border: 1px dashed var(--border-soft);
+    border-radius: 10px;
+    padding: 10px;
+    color: var(--muted-2);
+    font-size: 12px;
+}
+
+.kanban-card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 10px;
+    cursor: pointer;
+    transition: transform 0.15s ease, border-color 0.15s ease;
+    overflow: hidden;
+}
+
+.kanban-card:hover {
+    transform: translateY(-1px);
+    border-color: var(--primary);
+}
+
+.kanban-card h3 {
+    font-size: 14px;
+    line-height: 1.3;
+    margin-bottom: 8px;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.card-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.due-badge {
+    display: inline-block;
+    padding: 4px 8px;
+    border-radius: 999px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.2px;
+}
+
+.due-none {
+    background: rgba(148, 163, 184, 0.18);
+    color: var(--muted);
+}
+
+.due-overdue {
+    background: var(--danger-bg);
+    color: var(--danger);
+}
+
+.due-today {
+    background: var(--warning-bg);
+    color: var(--warning);
+}
+
+.due-soon {
+    background: var(--info-bg);
+    color: var(--info);
+}
+
+.due-later {
+    background: var(--success-bg);
+    color: var(--success);
+}
+
+@media (max-width: 900px) {
+    .board-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}
+
+.members-box {
+    background: var(--panel-soft);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    margin-bottom: 14px;
+    box-shadow: var(--shadow);
+}
+
+.members-box h2 {
+    margin-bottom: 10px;
+    font-size: 17px;
+}
+
+.members-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.member-chip {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 8px 10px;
+}
+
+.member-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.member-info strong {
+    font-size: 13px;
+}
+
+.member-info span {
+    font-size: 11px;
+    color: var(--muted-2);
+}
+
+.owner-badge {
+    display: inline-block;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: var(--info-bg);
+    color: var(--info);
+    font-size: 10px;
+    font-weight: 700;
+}
+
+.remove-member-btn {
+    background: var(--danger-bg);
+    color: var(--danger);
+    border-radius: 6px;
+    padding: 6px 8px;
+    font-size: 11px;
+}
+
+.add-member-box {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.add-member-box select {
+    flex: 1;
+    min-width: 220px;
+}
+
+.card-assignees {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin-top: 8px;
+}
+
+.assignee-badge {
+    display: inline-block;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: rgba(56, 189, 248, 0.16);
+    color: #bae6fd;
+    font-size: 10px;
+    font-weight: 700;
+}
+
+.assignee-more {
+    display: inline-block;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: rgba(148, 163, 184, 0.16);
+    color: var(--muted);
+    font-size: 10px;
+    font-weight: 700;
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/board-details/board-details.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/board-details/board-details.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BoardDetails } from './board-details';
+
+describe('BoardDetails', () => {
+  let component: BoardDetails;
+  let fixture: ComponentFixture<BoardDetails>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BoardDetails]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(BoardDetails);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/board-details/board-details.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/board-details/board-details.ts
@@ -1,0 +1,332 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { forkJoin } from 'rxjs';
+
+import { BoardModel, BoardMemberModel } from '../../core/models/board.model';
+import { BoardListModel } from '../../core/models/board-list.model';
+import { CardItemModel, CardAssignmentModel } from '../../core/models/card-item.model';
+
+import { Boards as BoardsService } from '../../core/services/boards';
+import { Cards as CardsService } from '../../core/services/cards';
+import { Lists as ListsService } from '../../core/services/lists';
+import { Users as UsersService, BackendUser } from '../../core/services/users';
+import { BoardAccess } from '../../core/services/board-access';
+
+interface KanbanColumn {
+  list: BoardListModel;
+  cards: CardItemModel[];
+}
+
+@Component({
+  selector: 'app-board-details',
+  imports: [CommonModule, RouterLink, FormsModule],
+  templateUrl: './board-details.html',
+  styleUrl: './board-details.scss',
+})
+export class BoardDetails implements OnInit {
+  board: BoardModel | null = null;
+  columns: KanbanColumn[] = [];
+  isLoading = true;
+  errorMessage = '';
+
+  currentBackendUser: BackendUser | null = null;
+
+  allUsers: BackendUser[] = [];
+  selectedMemberId = '';
+  addingMember = false;
+  memberError = '';
+  removingMemberId: string | null = null;
+
+  readonly systemLists = [
+    'Backlog',
+    'Ready',
+    'In progress',
+    'In review',
+    'Done'
+  ];
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private boardsService: BoardsService,
+    private cardsService: CardsService,
+    private listsService: ListsService,
+    private usersService: UsersService,
+    private boardAccess: BoardAccess
+  ) { }
+
+  ngOnInit(): void {
+    const boardId = this.route.snapshot.paramMap.get('id');
+
+    if (!boardId) {
+      this.errorMessage = 'Board id is missing.';
+      this.isLoading = false;
+      return;
+    }
+
+    this.loadUsers();
+
+    this.boardAccess.getCurrentBackendUser().subscribe({
+      next: (user) => {
+        this.currentBackendUser = user;
+
+        if (!user) {
+          this.router.navigate(['/boards']);
+          return;
+        }
+
+        this.loadBoard(boardId);
+      },
+      error: () => {
+        this.errorMessage = 'Failed to resolve current user.';
+        this.isLoading = false;
+      }
+    });
+  }
+
+  get availableUsers(): BackendUser[] {
+    const memberIds = new Set((this.board?.members ?? []).map(m => m.userId));
+    return this.allUsers.filter(user => !memberIds.has(user.id));
+  }
+
+  getColumnDescription(name: string): string {
+    switch (name) {
+      case 'Backlog':
+        return 'This item has not been started';
+      case 'Ready':
+        return 'This is ready to be picked up';
+      case 'In progress':
+        return 'This is actively being worked on';
+      case 'In review':
+        return 'This item is in review';
+      case 'Done':
+        return 'This has been completed';
+      default:
+        return '';
+    }
+  }
+
+  getMemberName(member: BoardMemberModel): string {
+    return member.user?.fullName || 'Unknown user';
+  }
+
+  getMemberEmail(member: BoardMemberModel): string {
+    return member.user?.email || '';
+  }
+
+  isOwnerMember(member: BoardMemberModel): boolean {
+    return !!this.board && member.userId === this.board.ownerId;
+  }
+
+  getCardAssigneeNames(card: CardItemModel): string[] {
+    const assignments = card.assignments ?? [];
+    const members = this.board?.members ?? [];
+
+    return assignments.map((assignment: CardAssignmentModel) => {
+      const fromAssignment = assignment.user?.fullName;
+      if (fromAssignment) {
+        return fromAssignment;
+      }
+
+      const matchingMember = members.find(member => member.userId === assignment.userId);
+      return matchingMember?.user?.fullName || 'Unknown user';
+    });
+  }
+
+  getVisibleAssigneeNames(card: CardItemModel): string[] {
+    return this.getCardAssigneeNames(card).slice(0, 2);
+  }
+
+  getRemainingAssigneeCount(card: CardItemModel): number {
+    const total = this.getCardAssigneeNames(card).length;
+    return total > 2 ? total - 2 : 0;
+  }
+
+  hasAssignees(card: CardItemModel): boolean {
+    return (card.assignments?.length ?? 0) > 0;
+  }
+
+  private loadUsers(): void {
+    this.usersService.getUsers().subscribe({
+      next: (users) => {
+        this.allUsers = users;
+      }
+    });
+  }
+
+  private getStartOfToday(): Date {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return today;
+  }
+
+  private getStartOfDate(dateString: string): Date {
+    const date = new Date(dateString);
+    date.setHours(0, 0, 0, 0);
+    return date;
+  }
+
+  getDueDateStatus(card: CardItemModel): 'none' | 'overdue' | 'today' | 'soon' | 'later' {
+    if (!card.dueDateUtc) {
+      return 'none';
+    }
+
+    const today = this.getStartOfToday().getTime();
+    const dueDate = this.getStartOfDate(card.dueDateUtc).getTime();
+    const diffDays = Math.floor((dueDate - today) / (1000 * 60 * 60 * 24));
+
+    if (diffDays < 0) return 'overdue';
+    if (diffDays === 0) return 'today';
+    if (diffDays <= 7) return 'soon';
+    return 'later';
+  }
+
+  private sortCardsByDueDate(cards: CardItemModel[]): CardItemModel[] {
+    return [...cards].sort((a, b) => {
+      const aDue = a.dueDateUtc ? new Date(a.dueDateUtc).getTime() : Number.MAX_SAFE_INTEGER;
+      const bDue = b.dueDateUtc ? new Date(b.dueDateUtc).getTime() : Number.MAX_SAFE_INTEGER;
+
+      if (aDue !== bDue) {
+        return aDue - bDue;
+      }
+
+      return a.position - b.position;
+    });
+  }
+
+  private loadBoard(boardId: string): void {
+    this.isLoading = true;
+    this.errorMessage = '';
+
+    this.boardsService.getBoardById(boardId).subscribe({
+      next: (board) => {
+        if (!this.boardAccess.canAccessBoard(board, this.currentBackendUser?.id)) {
+          this.router.navigate(['/boards']);
+          return;
+        }
+
+        this.board = board;
+
+        const existingLists = board.lists ?? [];
+        const existingNames = existingLists.map(l => l.name.trim().toLowerCase());
+
+        const missingLists = this.systemLists.filter(
+          name => !existingNames.includes(name.trim().toLowerCase())
+        );
+
+        if (missingLists.length > 0) {
+          forkJoin(
+            missingLists.map(name => this.listsService.createList(board.id, name))
+          ).subscribe({
+            next: () => this.loadBoard(boardId),
+            error: () => {
+              this.errorMessage = 'Failed to create the default columns.';
+              this.isLoading = false;
+            }
+          });
+          return;
+        }
+
+        const orderedLists: BoardListModel[] = this.systemLists
+          .map(systemName =>
+            existingLists.find(
+              l => l.name.trim().toLowerCase() === systemName.trim().toLowerCase()
+            )!
+          )
+          .filter(Boolean);
+
+        const requests = orderedLists.map(list => this.cardsService.getCardsByList(list.id));
+
+        forkJoin(requests).subscribe({
+          next: (cardsByList) => {
+            this.columns = orderedLists.map((list, index) => ({
+              list,
+              cards: this.sortCardsByDueDate(cardsByList[index] ?? [])
+            }));
+
+            this.isLoading = false;
+          },
+          error: () => {
+            this.errorMessage = 'Failed to load cards for this board.';
+            this.isLoading = false;
+          }
+        });
+      },
+      error: () => {
+        this.errorMessage = 'Failed to load board details.';
+        this.isLoading = false;
+      }
+    });
+  }
+
+  addMember(): void {
+    if (!this.board) {
+      return;
+    }
+
+    this.memberError = '';
+
+    if (!this.selectedMemberId) {
+      this.memberError = 'Please select a user.';
+      return;
+    }
+
+    this.addingMember = true;
+
+    this.boardsService.addMember(this.board.id, {
+      userId: this.selectedMemberId
+    }).subscribe({
+      next: () => {
+        this.selectedMemberId = '';
+        this.addingMember = false;
+        this.loadBoard(this.board!.id);
+      },
+      error: () => {
+        this.memberError = 'Failed to add member.';
+        this.addingMember = false;
+      }
+    });
+  }
+
+  removeMember(userId: string): void {
+    if (!this.board) {
+      return;
+    }
+
+    const shouldRemove = window.confirm('Are you sure you want to remove this member from the board?');
+    if (!shouldRemove) {
+      return;
+    }
+
+    this.removingMemberId = userId;
+
+    this.boardsService.removeMember(this.board.id, userId).subscribe({
+      next: () => {
+        this.removingMemberId = null;
+        this.loadBoard(this.board!.id);
+      },
+      error: () => {
+        this.memberError = 'Failed to remove member.';
+        this.removingMemberId = null;
+      }
+    });
+  }
+
+  openCard(cardId: string): void {
+    if (!this.board?.id) {
+      return;
+    }
+
+    this.router.navigate(['/boards', this.board.id, 'cards', cardId]);
+  }
+
+  goToCreateCard(): void {
+    if (!this.board?.id) {
+      return;
+    }
+
+    this.router.navigate(['/boards', this.board.id, 'cards', 'new']);
+  }
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/boards/boards.html
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/boards/boards.html
@@ -9,6 +9,24 @@
             <button type="button" (click)="loadBoards()">Refresh</button>
         </div>
 
+        <div class="create-board-box" (click)="$event.stopPropagation()">
+            <h2>Create new board</h2>
+
+            <div class="create-board-form">
+                <input type="text" [(ngModel)]="newBoardName" placeholder="Board name" />
+
+                <textarea [(ngModel)]="newBoardDescription" placeholder="Board description" rows="3"></textarea>
+
+                <button type="button" (click)="createBoard()" [disabled]="creatingBoard || resolvingCurrentUser">
+                    {{ creatingBoard ? 'Creating...' : 'Create board' }}
+                </button>
+            </div>
+
+            @if (createBoardError) {
+            <p class="form-error">{{ createBoardError }}</p>
+            }
+        </div>
+
         @if (isLoading) {
         <div class="state-box">
             Loading boards...
@@ -30,11 +48,53 @@
         @if (!isLoading && !errorMessage && boards.length > 0) {
         <div class="boards-grid">
             @for (board of boards; track board.id) {
-            <div class="board-card">
-                <h2>{{ board.name }}</h2>
-                <p>
-                    {{ board.description || 'No description available.' }}
-                </p>
+            <div class="board-card" (click)="openBoard(board.id)">
+                @if (editingBoardId === board.id) {
+                <div class="edit-board-box" (click)="$event.stopPropagation()">
+                    <input type="text" [(ngModel)]="editBoardById[board.id].name" placeholder="Board name" />
+
+                    <textarea [(ngModel)]="editBoardById[board.id].description" placeholder="Board description"
+                        rows="3"></textarea>
+
+                    <div class="board-actions">
+                        <button type="button" class="save-btn" (click)="saveEditBoard(board, $event)"
+                            [disabled]="savingBoardId === board.id">
+                            {{ savingBoardId === board.id ? 'Saving...' : 'Save' }}
+                        </button>
+
+                        <button type="button" class="cancel-btn" (click)="cancelEditBoard(board, $event)"
+                            [disabled]="savingBoardId === board.id">
+                            Cancel
+                        </button>
+                    </div>
+
+                    @if (editErrorByBoardId[board.id]) {
+                    <p class="form-error">{{ editErrorByBoardId[board.id] }}</p>
+                    }
+                </div>
+                } @else {
+                <div class="board-card-top">
+                    <div>
+                        <h2>{{ board.name }}</h2>
+                        <p>{{ board.description || 'No description available.' }}</p>
+                    </div>
+
+                    @if (isBoardOwner(board)) {
+                    <div class="board-owner-actions" (click)="$event.stopPropagation()">
+                        <button type="button" class="edit-btn" (click)="startEditBoard(board, $event)">
+                            Edit
+                        </button>
+
+                        <button type="button" class="delete-btn" (click)="deleteBoard(board.id, $event)"
+                            [disabled]="deletingBoardId === board.id">
+                            {{ deletingBoardId === board.id ? 'Deleting...' : 'Delete' }}
+                        </button>
+                    </div>
+                    }
+                </div>
+
+                <span class="open-text">Open board</span>
+                }
             </div>
             }
         </div>

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/boards/boards.scss
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/boards/boards.scss
@@ -1,83 +1,201 @@
 .boards-page {
     min-height: 100vh;
-    padding: 32px;
-    background: linear-gradient(135deg, #0f172a, #1e293b);
+    padding: 14px;
 }
 
 .boards-container {
-    max-width: 1100px;
+    max-width: 760px;
     margin: 0 auto;
 }
 
 .boards-header {
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    gap: 16px;
-    margin-bottom: 28px;
+    align-items: flex-start;
+    gap: 10px;
+    margin-bottom: 14px;
 }
 
 h1 {
-    margin: 0;
-    font-size: 40px;
-    color: #f8fafc;
+    font-size: 24px;
+    line-height: 1.05;
+    color: var(--text);
 }
 
 .subtitle {
-    margin-top: 8px;
-    color: #cbd5e1;
-}
-
-button {
-    border: none;
-    border-radius: 10px;
-    padding: 12px 18px;
-    font-size: 15px;
-    font-weight: 600;
-    cursor: pointer;
-    background: #38bdf8;
-    color: #082f49;
-}
-
-button:hover {
-    opacity: 0.95;
+    margin-top: 4px;
+    color: var(--muted);
+    font-size: 13px;
 }
 
 .state-box {
-    background: #111827;
-    color: #e5e7eb;
-    border-radius: 16px;
-    padding: 18px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+    background: var(--panel);
+    color: var(--text);
+    border-radius: 10px;
+    padding: 10px 12px;
+    box-shadow: var(--shadow);
+    font-size: 13px;
 }
 
 .error-box {
-    color: #fecaca;
+    color: var(--danger);
     background: rgba(239, 68, 68, 0.16);
 }
 
+.create-board-box {
+    background: var(--panel-soft);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    margin-bottom: 14px;
+    box-shadow: var(--shadow);
+}
+
+.create-board-box h2 {
+    margin-bottom: 10px;
+    font-size: 18px;
+}
+
+.create-board-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.create-board-form textarea {
+    min-height: 72px;
+}
+
+.create-board-form button {
+    align-self: flex-start;
+}
+
+.form-error {
+    margin-top: 6px;
+    color: var(--danger);
+    font-size: 12px;
+}
+
 .boards-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
 }
 
 .board-card {
-    background: #111827;
-    color: #f8fafc;
-    border-radius: 18px;
-    padding: 22px;
-    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.28);
-    border: 1px solid #1f2937;
+    background: var(--panel);
+    color: var(--text);
+    border-radius: 12px;
+    padding: 12px;
+    box-shadow: var(--shadow);
+    border: 1px solid var(--border);
+    cursor: pointer;
+    transition: transform 0.15s ease, border-color 0.15s ease;
+    overflow: hidden;
+}
+
+.board-card:hover {
+    transform: translateY(-1px);
+    border-color: var(--primary);
 }
 
 .board-card h2 {
-    margin: 0 0 12px;
-    font-size: 24px;
+    margin-bottom: 6px;
+    font-size: 17px;
+    line-height: 1.15;
 }
 
 .board-card p {
-    margin: 0;
-    color: #cbd5e1;
-    line-height: 1.5;
+    margin-bottom: 8px;
+    color: var(--muted);
+    line-height: 1.4;
+    font-size: 13px;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.board-card-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 10px;
+}
+
+.board-owner-actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+.edit-btn,
+.save-btn {
+    background: var(--info-bg);
+    color: var(--info);
+}
+
+.cancel-btn {
+    background: rgba(148, 163, 184, 0.18);
+    color: var(--muted);
+}
+
+.delete-btn {
+    background: var(--danger-bg);
+    color: var(--danger);
+}
+
+.edit-btn,
+.save-btn,
+.cancel-btn,
+.delete-btn {
+    border-radius: 6px;
+    padding: 6px 8px;
+    font-size: 11px;
+}
+
+.edit-board-box {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.edit-board-box textarea {
+    min-height: 72px;
+}
+
+.edit-board-box input,
+.edit-board-box textarea {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.board-actions {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.open-text {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--primary);
+}
+
+@media (max-width: 700px) {
+    .boards-page {
+        padding: 10px;
+    }
+
+    .boards-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .board-card-top {
+        flex-direction: column;
+    }
+
+    .board-owner-actions {
+        flex-wrap: wrap;
+    }
 }

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/boards/boards.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/boards/boards.ts
@@ -1,11 +1,18 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { forkJoin } from 'rxjs';
+
 import { BoardModel } from '../../core/models/board.model';
 import { Boards as BoardsService } from '../../core/services/boards';
+import { Lists as ListsService } from '../../core/services/lists';
+import { BackendUser } from '../../core/services/users';
+import { BoardAccess } from '../../core/services/board-access';
 
 @Component({
   selector: 'app-boards',
-  imports: [CommonModule],
+  imports: [CommonModule, FormsModule],
   templateUrl: './boards.html',
   styleUrl: './boards.scss',
 })
@@ -14,10 +21,49 @@ export class Boards implements OnInit {
   isLoading = true;
   errorMessage = '';
 
-  constructor(private boardsService: BoardsService) { }
+  currentBackendUser: BackendUser | null = null;
+  resolvingCurrentUser = true;
+
+  newBoardName = '';
+  newBoardDescription = '';
+  creatingBoard = false;
+  createBoardError = '';
+
+  editingBoardId: string | null = null;
+  editBoardById: Record<string, { name: string; description: string }> = {};
+  savingBoardId: string | null = null;
+  editErrorByBoardId: Record<string, string> = {};
+
+  deletingBoardId: string | null = null;
+
+  readonly defaultLists = [
+    'Backlog',
+    'Ready',
+    'In progress',
+    'In review',
+    'Done'
+  ];
+
+  constructor(
+    private boardsService: BoardsService,
+    private listsService: ListsService,
+    private boardAccess: BoardAccess,
+    private router: Router
+  ) { }
 
   ngOnInit(): void {
-    this.loadBoards();
+    this.boardAccess.getCurrentBackendUser().subscribe({
+      next: (user) => {
+        this.currentBackendUser = user;
+        this.resolvingCurrentUser = false;
+        this.loadBoards();
+      },
+      error: () => {
+        this.errorMessage = 'Failed to resolve current user.';
+        this.resolvingCurrentUser = false;
+        this.isLoading = false;
+      }
+    });
   }
 
   loadBoards(): void {
@@ -26,12 +72,157 @@ export class Boards implements OnInit {
 
     this.boardsService.getBoards().subscribe({
       next: (data) => {
-        this.boards = data;
+        this.boards = data.filter(board =>
+          this.boardAccess.canAccessBoard(board, this.currentBackendUser?.id)
+        );
+
+        for (const board of this.boards) {
+          this.editBoardById[board.id] = {
+            name: board.name,
+            description: board.description ?? ''
+          };
+        }
+
         this.isLoading = false;
       },
       error: () => {
         this.errorMessage = 'Failed to load boards.';
         this.isLoading = false;
+      }
+    });
+  }
+
+  openBoard(boardId: string): void {
+    this.router.navigate(['/boards', boardId]);
+  }
+
+  isBoardOwner(board: BoardModel): boolean {
+    return !!this.currentBackendUser && board.ownerId === this.currentBackendUser.id;
+  }
+
+  createBoard(): void {
+    const trimmedName = this.newBoardName.trim();
+    const trimmedDescription = this.newBoardDescription.trim();
+
+    this.createBoardError = '';
+
+    if (!this.currentBackendUser) {
+      this.createBoardError = 'Current user is not available.';
+      return;
+    }
+
+    if (!trimmedName) {
+      this.createBoardError = 'Board name is required.';
+      return;
+    }
+
+    this.creatingBoard = true;
+
+    this.boardsService.createBoard({
+      name: trimmedName,
+      description: trimmedDescription || null,
+      ownerId: this.currentBackendUser.id
+    }).subscribe({
+      next: (createdBoard) => {
+        forkJoin(
+          this.defaultLists.map(listName =>
+            this.listsService.createList(createdBoard.id, listName)
+          )
+        ).subscribe({
+          next: () => {
+            this.newBoardName = '';
+            this.newBoardDescription = '';
+            this.creatingBoard = false;
+            this.loadBoards();
+          },
+          error: () => {
+            this.createBoardError = 'Board was created, but default columns could not be created.';
+            this.creatingBoard = false;
+            this.loadBoards();
+          }
+        });
+      },
+      error: () => {
+        this.createBoardError = 'Failed to create board.';
+        this.creatingBoard = false;
+      }
+    });
+  }
+
+  startEditBoard(board: BoardModel, event: MouseEvent): void {
+    event.stopPropagation();
+
+    this.editingBoardId = board.id;
+    this.editErrorByBoardId[board.id] = '';
+
+    this.editBoardById[board.id] = {
+      name: board.name,
+      description: board.description ?? ''
+    };
+  }
+
+  cancelEditBoard(board: BoardModel, event?: MouseEvent): void {
+    event?.stopPropagation();
+
+    this.editingBoardId = null;
+    this.editErrorByBoardId[board.id] = '';
+
+    this.editBoardById[board.id] = {
+      name: board.name,
+      description: board.description ?? ''
+    };
+  }
+
+  saveEditBoard(board: BoardModel, event: MouseEvent): void {
+    event.stopPropagation();
+
+    const form = this.editBoardById[board.id];
+    const trimmedName = form.name.trim();
+    const trimmedDescription = form.description.trim();
+
+    this.editErrorByBoardId[board.id] = '';
+
+    if (!trimmedName) {
+      this.editErrorByBoardId[board.id] = 'Board name is required.';
+      return;
+    }
+
+    this.savingBoardId = board.id;
+
+    this.boardsService.updateBoard(board.id, {
+      name: trimmedName,
+      description: trimmedDescription || null
+    }).subscribe({
+      next: () => {
+        this.savingBoardId = null;
+        this.editingBoardId = null;
+        this.loadBoards();
+      },
+      error: () => {
+        this.editErrorByBoardId[board.id] = 'Failed to update board.';
+        this.savingBoardId = null;
+      }
+    });
+  }
+
+  deleteBoard(boardId: string, event: MouseEvent): void {
+    event.stopPropagation();
+
+    const shouldDelete = window.confirm('Are you sure you want to delete this board?');
+    if (!shouldDelete) {
+      return;
+    }
+
+    this.deletingBoardId = boardId;
+
+    this.boardsService.deleteBoard(boardId).subscribe({
+      next: () => {
+        this.deletingBoardId = null;
+        this.loadBoards();
+      },
+      error: () => {
+        this.errorMessage = 'Failed to delete board.';
+        this.deletingBoardId = null;
       }
     });
   }

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/card-details/card-details.html
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/card-details/card-details.html
@@ -1,0 +1,184 @@
+<div class="card-details-page">
+    <div class="card-details-container">
+        <div class="top-bar">
+            <a [routerLink]="['/boards', boardId]" class="back-link">
+                ← Back to board
+            </a>
+        </div>
+
+        @if (isLoading) {
+        <div class="state-box">Loading card...</div>
+        }
+
+        @if (!isLoading && errorMessage) {
+        <div class="state-box error-box">{{ errorMessage }}</div>
+        }
+
+        @if (!isLoading && card) {
+        <div class="card-panel">
+            @if (!isEditingCard) {
+            <div class="card-panel-top">
+                <div class="card-title-area">
+                    <h1>{{ card.title }}</h1>
+
+                    <div class="card-meta">
+                        <span class="due-badge" [ngClass]="'due-' + getDueDateStatus(card)">
+                            {{ getDueDateLabel(card) }}
+                        </span>
+
+                        @if (card.dueDateUtc) {
+                        <span class="due-date">
+                            {{ card.dueDateUtc | date:'mediumDate' }}
+                        </span>
+                        }
+                    </div>
+                </div>
+
+                <div class="card-main-actions">
+                    <button type="button" class="edit-btn" (click)="startEditCard()">
+                        Edit
+                    </button>
+
+                    <button type="button" class="delete-btn" (click)="deleteCard()" [disabled]="deletingCard">
+                        {{ deletingCard ? 'Deleting...' : 'Delete' }}
+                    </button>
+                </div>
+            </div>
+
+            <div class="card-description-box">
+                <h2>Description</h2>
+                <p>{{ card.description || 'No description available.' }}</p>
+            </div>
+
+            <div class="assignees-box">
+                <h2>Assignees</h2>
+
+                <div class="assignees-list">
+                    @if ((card.assignments ?? []).length === 0) {
+                    <div class="empty-inline">No assignees yet.</div>
+                    }
+
+                    @for (assignment of card.assignments ?? []; track assignment.userId) {
+                    <div class="assignee-chip">
+                        <span>{{ getAssignmentName(assignment) }}</span>
+
+                        <button type="button" class="remove-assignee-btn" (click)="unassignUser(assignment.userId)"
+                            [disabled]="unassigningUserId === assignment.userId">
+                            {{ unassigningUserId === assignment.userId ? 'Removing...' : 'Remove' }}
+                        </button>
+                    </div>
+                    }
+                </div>
+
+                <div class="assign-form">
+                    <select [(ngModel)]="selectedAssigneeId">
+                        <option value="">Select member</option>
+                        @for (member of availableAssignees; track member.id) {
+                        <option [value]="member.id">{{ member.fullName }} — {{ member.email }}</option>
+                        }
+                    </select>
+
+                    <button type="button" class="assign-btn" (click)="assignUser()" [disabled]="assigningUser">
+                        {{ assigningUser ? 'Assigning...' : 'Assign member' }}
+                    </button>
+                </div>
+
+                @if (assignError) {
+                <p class="form-error">{{ assignError }}</p>
+                }
+            </div>
+
+            <div class="move-card-box">
+                <h2>Change column</h2>
+
+                <div class="move-card-form">
+                    <select [(ngModel)]="selectedTargetListId">
+                        @for (target of moveTargets; track target.id) {
+                        <option [value]="target.id">{{ target.name }}</option>
+                        }
+                    </select>
+
+                    <button type="button" class="move-btn" (click)="moveCard()" [disabled]="movingCard">
+                        {{ movingCard ? 'Moving...' : 'Move card' }}
+                    </button>
+                </div>
+
+                @if (moveCardError) {
+                <p class="form-error">{{ moveCardError }}</p>
+                }
+            </div>
+            } @else {
+            <div class="card-panel-top">
+                <h1>Edit card</h1>
+            </div>
+
+            <div class="edit-card-form">
+                <input type="text" [(ngModel)]="editTitle" placeholder="Card title" />
+
+                <textarea [(ngModel)]="editDescription" placeholder="Card description" rows="5"></textarea>
+
+                <input type="date" [(ngModel)]="editDueDate" [min]="minDate" />
+
+                <div class="card-main-actions">
+                    <button type="button" class="save-btn" (click)="saveCard()" [disabled]="savingCard">
+                        {{ savingCard ? 'Saving...' : 'Save changes' }}
+                    </button>
+
+                    <button type="button" class="cancel-btn" (click)="cancelEditCard()" [disabled]="savingCard">
+                        Cancel
+                    </button>
+                </div>
+            </div>
+
+            @if (editCardError) {
+            <p class="form-error">{{ editCardError }}</p>
+            }
+            }
+        </div>
+
+        <div class="comments-panel">
+            <h2>Comments</h2>
+
+            <div class="create-comment-box">
+                <textarea [(ngModel)]="newCommentMessage" placeholder="Write a comment..." rows="3"></textarea>
+
+                <button type="button" (click)="createComment()" [disabled]="creatingComment">
+                    {{ creatingComment ? 'Posting...' : 'Add comment' }}
+                </button>
+            </div>
+
+            @if (createCommentError) {
+            <p class="form-error">{{ createCommentError }}</p>
+            }
+
+            @if (comments.length === 0) {
+            <div class="state-box">No comments yet.</div>
+            }
+
+            @if (comments.length > 0) {
+            <div class="comments-list">
+                @for (comment of comments; track comment.id) {
+                <div class="comment-item">
+                    <div class="comment-top">
+                        <div>
+                            <h3>{{ comment.author?.fullName || 'Unknown user' }}</h3>
+                            <span class="comment-date">
+                                {{ comment.createdAtUtc | date:'medium' }}
+                            </span>
+                        </div>
+
+                        <button type="button" class="delete-comment-btn" (click)="deleteComment(comment.id)"
+                            [disabled]="deletingCommentId === comment.id">
+                            {{ deletingCommentId === comment.id ? 'Deleting...' : 'Delete' }}
+                        </button>
+                    </div>
+
+                    <p>{{ comment.message }}</p>
+                </div>
+                }
+            </div>
+            }
+        </div>
+        }
+    </div>
+</div>

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/card-details/card-details.scss
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/card-details/card-details.scss
@@ -1,0 +1,334 @@
+.card-details-page {
+    min-height: 100vh;
+    padding: 16px;
+}
+
+.card-details-container {
+    max-width: 820px;
+    margin: 0 auto;
+}
+
+.top-bar {
+    margin-bottom: 14px;
+}
+
+.back-link {
+    font-weight: 600;
+    font-size: 13px;
+}
+
+.state-box {
+    background: var(--panel);
+    color: var(--text);
+    border-radius: 10px;
+    padding: 10px 12px;
+}
+
+.error-box {
+    color: var(--danger);
+    background: rgba(239, 68, 68, 0.16);
+}
+
+.card-panel,
+.comments-panel {
+    background: var(--panel-soft);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 14px;
+    margin-bottom: 14px;
+    box-shadow: var(--shadow);
+}
+
+.card-panel-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.card-title-area {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.card-title-area h1,
+.card-panel-top h1 {
+    font-size: 24px;
+    line-height: 1.1;
+    color: var(--text);
+}
+
+.card-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.card-main-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.edit-btn,
+.save-btn {
+    background: var(--info-bg);
+    color: var(--info);
+}
+
+.cancel-btn {
+    background: rgba(148, 163, 184, 0.18);
+    color: var(--muted);
+}
+
+.delete-btn,
+.delete-comment-btn {
+    background: var(--danger-bg);
+    color: var(--danger);
+}
+
+.move-btn {
+    background: var(--success-bg);
+    color: var(--success);
+}
+
+.edit-btn,
+.save-btn,
+.cancel-btn,
+.delete-btn,
+.delete-comment-btn,
+.move-btn {
+    border-radius: 8px;
+    padding: 7px 10px;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.card-description-box,
+.move-card-box {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+}
+
+.card-description-box {
+    margin-bottom: 12px;
+}
+
+.card-description-box h2,
+.move-card-box h2,
+.comments-panel h2 {
+    margin-bottom: 8px;
+    font-size: 17px;
+}
+
+.card-description-box p {
+    color: var(--muted);
+    font-size: 13px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.move-card-form {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.move-card-form select {
+    flex: 1;
+    min-width: 180px;
+}
+
+.edit-card-form,
+.create-comment-box {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.edit-card-form textarea {
+    min-height: 110px;
+}
+
+.create-comment-box textarea {
+    min-height: 76px;
+}
+
+.edit-card-form button,
+.create-comment-box button {
+    align-self: flex-start;
+}
+
+.form-error {
+    margin-top: 8px;
+    color: var(--danger);
+    font-size: 12px;
+}
+
+.comments-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 12px;
+}
+
+.comment-item {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    overflow: hidden;
+}
+
+.comment-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 10px;
+    margin-bottom: 8px;
+}
+
+.comment-top h3 {
+    font-size: 14px;
+}
+
+.comment-date {
+    display: inline-block;
+    margin-top: 2px;
+    font-size: 11px;
+    color: var(--muted-2);
+}
+
+.comment-item p {
+    color: var(--muted);
+    font-size: 13px;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
+.due-badge {
+    display: inline-block;
+    padding: 4px 8px;
+    border-radius: 999px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.2px;
+}
+
+.due-none {
+    background: rgba(148, 163, 184, 0.18);
+    color: var(--muted);
+}
+
+.due-overdue {
+    background: var(--danger-bg);
+    color: var(--danger);
+}
+
+.due-today {
+    background: var(--warning-bg);
+    color: var(--warning);
+}
+
+.due-soon {
+    background: var(--info-bg);
+    color: var(--info);
+}
+
+.due-later {
+    background: var(--success-bg);
+    color: var(--success);
+}
+
+.due-date {
+    display: inline-block;
+    font-size: 11px;
+    color: var(--primary);
+    font-weight: 600;
+}
+
+@media (max-width: 700px) {
+    .card-details-page {
+        padding: 10px;
+    }
+
+    .card-panel-top,
+    .comment-top {
+        flex-direction: column;
+    }
+
+    .move-card-form,
+    .card-main-actions {
+        width: 100%;
+    }
+}
+
+.assignees-box {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 12px;
+    margin-bottom: 12px;
+}
+
+.assignees-box h2 {
+    margin-bottom: 8px;
+    font-size: 17px;
+}
+
+.assignees-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.assignee-chip {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: rgba(148, 163, 184, 0.12);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 6px 10px;
+    font-size: 12px;
+}
+
+.remove-assignee-btn {
+    background: var(--danger-bg);
+    color: var(--danger);
+    border-radius: 6px;
+    padding: 5px 7px;
+    font-size: 11px;
+}
+
+.assign-form {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.assign-form select {
+    flex: 1;
+    min-width: 220px;
+}
+
+.assign-btn {
+    background: var(--info-bg);
+    color: var(--info);
+}
+
+.empty-inline {
+    color: var(--muted-2);
+    font-size: 12px;
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/card-details/card-details.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/card-details/card-details.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CardDetails } from './card-details';
+
+describe('CardDetails', () => {
+  let component: CardDetails;
+  let fixture: ComponentFixture<CardDetails>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CardDetails]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CardDetails);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/card-details/card-details.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/card-details/card-details.ts
@@ -1,0 +1,487 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { forkJoin } from 'rxjs';
+
+import { CardItemModel, CardAssignmentModel } from '../../core/models/card-item.model';
+import { CardCommentModel } from '../../core/models/card-comment.model';
+import { BoardListModel } from '../../core/models/board-list.model';
+import { BoardModel } from '../../core/models/board.model';
+
+import { Cards as CardsService } from '../../core/services/cards';
+import { Comments as CommentsService } from '../../core/services/comments';
+import { Boards as BoardsService } from '../../core/services/boards';
+import { BackendUser } from '../../core/services/users';
+import { BoardAccess } from '../../core/services/board-access';
+
+interface MoveTargetOption {
+  id: string;
+  name: string;
+  cardCount: number;
+}
+
+@Component({
+  selector: 'app-card-details',
+  imports: [CommonModule, RouterLink, FormsModule],
+  templateUrl: './card-details.html',
+  styleUrl: './card-details.scss',
+})
+export class CardDetails implements OnInit {
+  card: CardItemModel | null = null;
+  comments: CardCommentModel[] = [];
+  isLoading = true;
+  errorMessage = '';
+
+  currentBackendUser: BackendUser | null = null;
+
+  boardId = '';
+  cardId = '';
+
+  moveTargets: MoveTargetOption[] = [];
+  selectedTargetListId = '';
+  movingCard = false;
+  moveCardError = '';
+
+  boardMembers: BackendUser[] = [];
+  selectedAssigneeId = '';
+  assignError = '';
+  assigningUser = false;
+  unassigningUserId: string | null = null;
+
+  isEditingCard = false;
+  editTitle = '';
+  editDescription = '';
+  editDueDate = '';
+  savingCard = false;
+  editCardError = '';
+
+  newCommentMessage = '';
+  creatingComment = false;
+  createCommentError = '';
+
+  deletingCard = false;
+  deletingCommentId: string | null = null;
+
+  readonly minDate = this.getTodayAsInputDate();
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private cardsService: CardsService,
+    private commentsService: CommentsService,
+    private boardsService: BoardsService,
+    private boardAccess: BoardAccess
+  ) { }
+
+  ngOnInit(): void {
+    this.boardId = this.route.snapshot.paramMap.get('boardId') ?? '';
+    this.cardId = this.route.snapshot.paramMap.get('cardId') ?? '';
+
+    if (!this.cardId) {
+      this.errorMessage = 'Card id is missing.';
+      this.isLoading = false;
+      return;
+    }
+
+    this.boardAccess.getCurrentBackendUser().subscribe({
+      next: (user) => {
+        this.currentBackendUser = user;
+
+        if (!user) {
+          this.router.navigate(['/boards']);
+          return;
+        }
+
+        if (this.boardId) {
+          this.loadBoardContext(this.boardId);
+        }
+
+        this.loadCardDetails(this.cardId);
+      },
+      error: () => {
+        this.errorMessage = 'Failed to resolve current user.';
+        this.isLoading = false;
+      }
+    });
+  }
+
+  get availableAssignees(): BackendUser[] {
+    const assignedIds = new Set((this.card?.assignments ?? []).map(a => a.userId));
+    return this.boardMembers.filter(member => !assignedIds.has(member.id));
+  }
+
+  private getTodayAsInputDate(): string {
+    const now = new Date();
+    const offset = now.getTimezoneOffset();
+    return new Date(now.getTime() - offset * 60000).toISOString().split('T')[0];
+  }
+
+  private getInputDateValue(dateString?: string | null): string {
+    if (!dateString) {
+      return '';
+    }
+
+    const date = new Date(dateString);
+    const offset = date.getTimezoneOffset();
+    return new Date(date.getTime() - offset * 60000).toISOString().split('T')[0];
+  }
+
+  private getStartOfToday(): Date {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return today;
+  }
+
+  private getStartOfDate(dateString: string): Date {
+    const date = new Date(dateString);
+    date.setHours(0, 0, 0, 0);
+    return date;
+  }
+
+  getDueDateStatus(card: CardItemModel): 'none' | 'overdue' | 'today' | 'soon' | 'later' {
+    if (!card.dueDateUtc) {
+      return 'none';
+    }
+
+    const today = this.getStartOfToday().getTime();
+    const dueDate = this.getStartOfDate(card.dueDateUtc).getTime();
+    const diffDays = Math.floor((dueDate - today) / (1000 * 60 * 60 * 24));
+
+    if (diffDays < 0) return 'overdue';
+    if (diffDays === 0) return 'today';
+    if (diffDays <= 7) return 'soon';
+    return 'later';
+  }
+
+  getDueDateLabel(card: CardItemModel): string {
+    const status = this.getDueDateStatus(card);
+
+    switch (status) {
+      case 'overdue':
+        return 'Overdue';
+      case 'today':
+        return 'Due today';
+      case 'soon':
+        return 'Due soon';
+      case 'later':
+        return 'Upcoming';
+      default:
+        return 'No due date';
+    }
+  }
+
+  getAssignmentName(assignment: CardAssignmentModel): string {
+    return (
+      assignment.user?.fullName ||
+      this.boardMembers.find(m => m.id === assignment.userId)?.fullName ||
+      'Unknown user'
+    );
+  }
+
+  private loadBoardContext(boardId: string): void {
+    this.boardsService.getBoardById(boardId).subscribe({
+      next: (board: BoardModel) => {
+        if (!this.boardAccess.canAccessBoard(board, this.currentBackendUser?.id)) {
+          this.router.navigate(['/boards']);
+          return;
+        }
+
+        this.boardMembers = (board.members ?? [])
+          .map(member => member.user)
+          .filter((user): user is BackendUser => !!user);
+
+        const systemOrder = ['Backlog', 'Ready', 'In progress', 'In review', 'Done'];
+
+        const orderedLists = systemOrder
+          .map(name => (board.lists ?? []).find(
+            l => l.name.trim().toLowerCase() === name.trim().toLowerCase()
+          ))
+          .filter((list): list is BoardListModel => !!list);
+
+        if (orderedLists.length === 0) {
+          this.moveTargets = [];
+          return;
+        }
+
+        forkJoin(
+          orderedLists.map(list => this.cardsService.getCardsByList(list.id))
+        ).subscribe({
+          next: (cardsByList) => {
+            this.moveTargets = orderedLists.map((list, index) => ({
+              id: list.id,
+              name: list.name,
+              cardCount: cardsByList[index]?.length ?? 0
+            }));
+          },
+          error: () => {
+            this.moveCardError = 'Failed to load board columns.';
+          }
+        });
+      },
+      error: () => {
+        this.moveCardError = 'Failed to load board columns.';
+      }
+    });
+  }
+
+  private loadCardDetails(cardId: string): void {
+    this.isLoading = true;
+    this.errorMessage = '';
+
+    this.cardsService.getCardById(cardId).subscribe({
+      next: (card) => {
+        this.card = card;
+        this.editTitle = card.title;
+        this.editDescription = card.description ?? '';
+        this.editDueDate = this.getInputDateValue(card.dueDateUtc);
+        this.selectedTargetListId = card.listId;
+
+        this.commentsService.getCommentsByCard(cardId).subscribe({
+          next: (comments) => {
+            this.comments = comments;
+            this.isLoading = false;
+          },
+          error: () => {
+            this.errorMessage = 'Failed to load comments.';
+            this.isLoading = false;
+          }
+        });
+      },
+      error: () => {
+        this.errorMessage = 'Failed to load card details.';
+        this.isLoading = false;
+      }
+    });
+  }
+
+  startEditCard(): void {
+    if (!this.card) return;
+
+    this.editCardError = '';
+    this.editTitle = this.card.title;
+    this.editDescription = this.card.description ?? '';
+    this.editDueDate = this.getInputDateValue(this.card.dueDateUtc);
+    this.isEditingCard = true;
+  }
+
+  cancelEditCard(): void {
+    if (!this.card) {
+      this.isEditingCard = false;
+      return;
+    }
+
+    this.editCardError = '';
+    this.editTitle = this.card.title;
+    this.editDescription = this.card.description ?? '';
+    this.editDueDate = this.getInputDateValue(this.card.dueDateUtc);
+    this.isEditingCard = false;
+  }
+
+  saveCard(): void {
+    if (!this.card) return;
+
+    const trimmedTitle = this.editTitle.trim();
+    const trimmedDescription = this.editDescription.trim();
+
+    this.editCardError = '';
+
+    if (!trimmedTitle) {
+      this.editCardError = 'Card title is required.';
+      return;
+    }
+
+    if (this.editDueDate && this.editDueDate < this.minDate) {
+      this.editCardError = 'Due date cannot be in the past.';
+      return;
+    }
+
+    this.savingCard = true;
+
+    this.cardsService.updateCard(this.card.id, {
+      title: trimmedTitle,
+      description: trimmedDescription || null,
+      position: this.card.position,
+      dueDateUtc: this.editDueDate ? new Date(this.editDueDate).toISOString() : null
+    }).subscribe({
+      next: () => {
+        this.savingCard = false;
+        this.isEditingCard = false;
+        this.loadCardDetails(this.card!.id);
+      },
+      error: () => {
+        this.editCardError = 'Failed to update card.';
+        this.savingCard = false;
+      }
+    });
+  }
+
+  moveCard(): void {
+    if (!this.card) {
+      return;
+    }
+
+    this.moveCardError = '';
+
+    if (!this.selectedTargetListId) {
+      this.moveCardError = 'Please select a target column.';
+      return;
+    }
+
+    if (this.selectedTargetListId === this.card.listId) {
+      this.moveCardError = 'Card is already in this column.';
+      return;
+    }
+
+    const target = this.moveTargets.find(t => t.id === this.selectedTargetListId);
+    if (!target) {
+      this.moveCardError = 'Target column was not found.';
+      return;
+    }
+
+    this.movingCard = true;
+
+    this.cardsService.moveCard(this.card.id, {
+      TargetListId: this.selectedTargetListId,
+      TargetPosition: target.cardCount + 1
+    }).subscribe({
+      next: () => {
+        this.movingCard = false;
+        this.loadBoardContext(this.boardId);
+        this.loadCardDetails(this.card!.id);
+      },
+      error: (err) => {
+        const backendMessage = err?.error?.message;
+        this.moveCardError = backendMessage || 'Failed to move card.';
+        this.movingCard = false;
+      }
+    });
+  }
+
+  assignUser(): void {
+    if (!this.card) {
+      return;
+    }
+
+    this.assignError = '';
+
+    if (!this.selectedAssigneeId) {
+      this.assignError = 'Please select a member.';
+      return;
+    }
+
+    this.assigningUser = true;
+
+    this.cardsService.assignUser(this.card.id, this.selectedAssigneeId).subscribe({
+      next: () => {
+        this.selectedAssigneeId = '';
+        this.assigningUser = false;
+        this.loadCardDetails(this.card!.id);
+      },
+      error: (err) => {
+        const backendMessage = err?.error?.message;
+        this.assignError = backendMessage || 'Failed to assign user.';
+        this.assigningUser = false;
+      }
+    });
+  }
+
+  unassignUser(userId: string): void {
+    if (!this.card) {
+      return;
+    }
+
+    this.unassigningUserId = userId;
+
+    this.cardsService.unassignUser(this.card.id, userId).subscribe({
+      next: () => {
+        this.unassigningUserId = null;
+        this.loadCardDetails(this.card!.id);
+      },
+      error: () => {
+        this.assignError = 'Failed to unassign user.';
+        this.unassigningUserId = null;
+      }
+    });
+  }
+
+  deleteCard(): void {
+    if (!this.card) return;
+
+    const shouldDelete = window.confirm('Are you sure you want to delete this card?');
+    if (!shouldDelete) return;
+
+    this.deletingCard = true;
+
+    this.cardsService.deleteCard(this.card.id).subscribe({
+      next: () => {
+        this.deletingCard = false;
+        if (this.boardId) {
+          this.router.navigate(['/boards', this.boardId]);
+        }
+      },
+      error: () => {
+        this.errorMessage = 'Failed to delete card.';
+        this.deletingCard = false;
+      }
+    });
+  }
+
+  createComment(): void {
+    const trimmedMessage = this.newCommentMessage.trim();
+
+    this.createCommentError = '';
+
+    if (!this.card) {
+      this.createCommentError = 'Card not found.';
+      return;
+    }
+
+    if (!this.currentBackendUser) {
+      this.createCommentError = 'Current user is not available.';
+      return;
+    }
+
+    if (!trimmedMessage) {
+      this.createCommentError = 'Comment message is required.';
+      return;
+    }
+
+    this.creatingComment = true;
+
+    this.commentsService.createComment(this.card.id, {
+      authorId: this.currentBackendUser.id,
+      message: trimmedMessage
+    }).subscribe({
+      next: () => {
+        this.newCommentMessage = '';
+        this.creatingComment = false;
+        this.loadCardDetails(this.card!.id);
+      },
+      error: () => {
+        this.createCommentError = 'Failed to create comment.';
+        this.creatingComment = false;
+      }
+    });
+  }
+
+  deleteComment(commentId: string): void {
+    if (!this.card) return;
+
+    const shouldDelete = window.confirm('Are you sure you want to delete this comment?');
+    if (!shouldDelete) return;
+
+    this.deletingCommentId = commentId;
+
+    this.commentsService.deleteComment(commentId).subscribe({
+      next: () => {
+        this.deletingCommentId = null;
+        this.loadCardDetails(this.card!.id);
+      },
+      error: () => {
+        this.errorMessage = 'Failed to delete comment.';
+        this.deletingCommentId = null;
+      }
+    });
+  }
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/create-card/create-card.html
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/create-card/create-card.html
@@ -1,0 +1,40 @@
+<div class="create-card-page">
+    <div class="create-card-container">
+        <div class="top-bar">
+            <a [routerLink]="['/boards', boardId]" class="back-link">← Back to board</a>
+        </div>
+
+        @if (isLoading) {
+        <div class="state-box">Loading board...</div>
+        }
+
+        @if (!isLoading && errorMessage) {
+        <div class="state-box error-box">{{ errorMessage }}</div>
+        }
+
+        @if (!isLoading && board && backlogList) {
+        <div class="create-card-box">
+            <h1>New card</h1>
+            <p class="subtitle">
+                This card will be created automatically in <strong>Backlog</strong>.
+            </p>
+
+            <div class="create-card-form">
+                <input type="text" [(ngModel)]="title" placeholder="Card title" />
+
+                <textarea [(ngModel)]="description" placeholder="Card description" rows="5"></textarea>
+
+                <input type="date" [(ngModel)]="dueDate" [min]="minDate" />
+
+                <button type="button" (click)="createCard()" [disabled]="creatingCard">
+                    {{ creatingCard ? 'Creating...' : 'Create card' }}
+                </button>
+            </div>
+
+            @if (createCardError) {
+            <p class="form-error">{{ createCardError }}</p>
+            }
+        </div>
+        }
+    </div>
+</div>

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/create-card/create-card.scss
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/create-card/create-card.scss
@@ -1,0 +1,70 @@
+.create-card-page {
+    min-height: 100vh;
+    padding: 14px;
+}
+
+.create-card-container {
+    max-width: 760px;
+    margin: 0 auto;
+}
+
+.top-bar {
+    margin-bottom: 12px;
+}
+
+.back-link {
+    font-weight: 600;
+    font-size: 13px;
+}
+
+.state-box {
+    background: var(--panel);
+    color: var(--text);
+    border-radius: 10px;
+    padding: 10px 12px;
+}
+
+.error-box {
+    color: var(--danger);
+    background: rgba(239, 68, 68, 0.16);
+}
+
+.create-card-box {
+    background: var(--panel-soft);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    box-shadow: var(--shadow);
+}
+
+.create-card-box h1 {
+    font-size: 24px;
+    line-height: 1.05;
+    margin-bottom: 6px;
+}
+
+.subtitle {
+    color: var(--muted);
+    font-size: 13px;
+    margin-bottom: 12px;
+}
+
+.create-card-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.create-card-form textarea {
+    min-height: 110px;
+}
+
+.create-card-form button {
+    align-self: flex-start;
+}
+
+.form-error {
+    margin-top: 6px;
+    color: var(--danger);
+    font-size: 12px;
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/create-card/create-card.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/create-card/create-card.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateCard } from './create-card';
+
+describe('CreateCard', () => {
+  let component: CreateCard;
+  let fixture: ComponentFixture<CreateCard>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CreateCard]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CreateCard);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/create-card/create-card.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/create-card/create-card.ts
@@ -1,0 +1,147 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+
+import { BoardModel } from '../../core/models/board.model';
+import { BoardListModel } from '../../core/models/board-list.model';
+
+import { Boards as BoardsService } from '../../core/services/boards';
+import { Cards as CardsService } from '../../core/services/cards';
+import { BoardAccess } from '../../core/services/board-access';
+import { BackendUser } from '../../core/services/users';
+
+@Component({
+  selector: 'app-create-card',
+  imports: [CommonModule, FormsModule, RouterLink],
+  templateUrl: './create-card.html',
+  styleUrl: './create-card.scss',
+})
+export class CreateCard implements OnInit {
+  boardId = '';
+  board: BoardModel | null = null;
+  backlogList: BoardListModel | null = null;
+
+  currentBackendUser: BackendUser | null = null;
+
+  isLoading = true;
+  errorMessage = '';
+
+  title = '';
+  description = '';
+  dueDate = '';
+  creatingCard = false;
+  createCardError = '';
+
+  readonly minDate = this.getTodayAsInputDate();
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private boardsService: BoardsService,
+    private cardsService: CardsService,
+    private boardAccess: BoardAccess
+  ) { }
+
+  ngOnInit(): void {
+    this.boardId = this.route.snapshot.paramMap.get('boardId') ?? '';
+
+    if (!this.boardId) {
+      this.errorMessage = 'Board id is missing.';
+      this.isLoading = false;
+      return;
+    }
+
+    this.boardAccess.getCurrentBackendUser().subscribe({
+      next: (user) => {
+        this.currentBackendUser = user;
+
+        if (!user) {
+          this.router.navigate(['/boards']);
+          return;
+        }
+
+        this.loadBoard();
+      },
+      error: () => {
+        this.errorMessage = 'Failed to resolve current user.';
+        this.isLoading = false;
+      }
+    });
+  }
+
+  private getTodayAsInputDate(): string {
+    const now = new Date();
+    const offset = now.getTimezoneOffset();
+    return new Date(now.getTime() - offset * 60000).toISOString().split('T')[0];
+  }
+
+  private loadBoard(): void {
+    this.isLoading = true;
+    this.errorMessage = '';
+
+    this.boardsService.getBoardById(this.boardId).subscribe({
+      next: (board) => {
+        if (!this.boardAccess.canAccessBoard(board, this.currentBackendUser?.id)) {
+          this.router.navigate(['/boards']);
+          return;
+        }
+
+        this.board = board;
+
+        const lists = board.lists ?? [];
+        this.backlogList =
+          lists.find(l => l.name.trim().toLowerCase() === 'backlog') ?? null;
+
+        if (!this.backlogList) {
+          this.errorMessage = 'Backlog column was not found for this board.';
+        }
+
+        this.isLoading = false;
+      },
+      error: () => {
+        this.errorMessage = 'Failed to load board.';
+        this.isLoading = false;
+      }
+    });
+  }
+
+  createCard(): void {
+    const trimmedTitle = this.title.trim();
+    const trimmedDescription = this.description.trim();
+
+    this.createCardError = '';
+
+    if (!this.backlogList) {
+      this.createCardError = 'Backlog column was not found.';
+      return;
+    }
+
+    if (!trimmedTitle) {
+      this.createCardError = 'Card title is required.';
+      return;
+    }
+
+    if (this.dueDate && this.dueDate < this.minDate) {
+      this.createCardError = 'Due date cannot be in the past.';
+      return;
+    }
+
+    this.creatingCard = true;
+
+    this.cardsService.createCard(this.backlogList.id, {
+      title: trimmedTitle,
+      description: trimmedDescription || null,
+      dueDateUtc: this.dueDate ? new Date(this.dueDate).toISOString() : null
+    }).subscribe({
+      next: () => {
+        this.creatingCard = false;
+        this.router.navigate(['/boards', this.boardId]);
+      },
+      error: () => {
+        this.createCardError = 'Failed to create card.';
+        this.creatingCard = false;
+      }
+    });
+  }
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/list-details/list-details.html
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/list-details/list-details.html
@@ -1,0 +1,64 @@
+<div class="list-details-page">
+    <div class="list-details-container">
+        <div class="top-bar">
+            <a [routerLink]="['/boards', list?.boardId]" class="back-link">
+                ← Back to board
+            </a>
+        </div>
+
+        @if (isLoading) {
+        <div class="state-box">Loading list...</div>
+        }
+
+        @if (!isLoading && errorMessage) {
+        <div class="state-box error-box">{{ errorMessage }}</div>
+        }
+
+        @if (!isLoading && list) {
+        <div class="list-header-box">
+            <h1>{{ list.name }}</h1>
+            <p>Open a card to view full details and comments.</p>
+        </div>
+
+        <div class="create-card-box">
+            <h2>Add new card</h2>
+
+            <div class="create-card-form">
+                <input type="text" [(ngModel)]="newCardTitle" placeholder="Card title" />
+
+                <textarea [(ngModel)]="newCardDescription" placeholder="Card description" rows="3"></textarea>
+
+                <input type="date" [(ngModel)]="newCardDueDate" [min]="minDate" />
+
+                <button type="button" (click)="createCard()" [disabled]="creatingCard">
+                    {{ creatingCard ? 'Creating...' : 'Add card' }}
+                </button>
+            </div>
+
+            @if (createCardError) {
+            <p class="form-error">{{ createCardError }}</p>
+            }
+        </div>
+
+        @if (cards.length === 0) {
+        <div class="state-box">No cards found for this list.</div>
+        }
+
+        @if (cards.length > 0) {
+        <div class="cards-list">
+            @for (card of cards; track card.id) {
+            <div class="card-item compact-card" (click)="openCard(card.id)">
+                <div class="card-top-row">
+                    <h3>{{ card.title }}</h3>
+
+                    <span class="due-badge" [ngClass]="'due-' + getDueDateStatus(card)">
+                        {{ card.dueDateUtc ? (card.dueDateUtc | date:'mediumDate') : 'No due date' }}
+                    </span>
+                </div>
+            </div>
+            }
+        </div>
+        }
+        }
+    </div>
+</div>

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/list-details/list-details.scss
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/list-details/list-details.scss
@@ -1,0 +1,156 @@
+.list-details-page {
+    min-height: 100vh;
+    padding: 14px;
+}
+
+.list-details-container {
+    max-width: 760px;
+    margin: 0 auto;
+}
+
+.top-bar {
+    margin-bottom: 12px;
+}
+
+.back-link {
+    font-weight: 600;
+    font-size: 13px;
+}
+
+.list-header-box {
+    background: var(--panel-soft);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    margin-bottom: 14px;
+    box-shadow: var(--shadow);
+}
+
+.list-header-box h1 {
+    margin-bottom: 4px;
+    font-size: 22px;
+    line-height: 1.05;
+    color: var(--text);
+}
+
+.list-header-box p {
+    color: var(--muted);
+    font-size: 13px;
+}
+
+.state-box {
+    background: var(--panel);
+    color: var(--text);
+    border-radius: 10px;
+    padding: 10px 12px;
+}
+
+.error-box {
+    color: var(--danger);
+    background: rgba(239, 68, 68, 0.16);
+}
+
+.create-card-box {
+    background: var(--panel-soft);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    margin-bottom: 14px;
+    box-shadow: var(--shadow);
+}
+
+.create-card-box h2 {
+    margin-bottom: 10px;
+    font-size: 17px;
+}
+
+.create-card-form {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.create-card-form textarea {
+    min-height: 72px;
+}
+
+.create-card-form button {
+    align-self: flex-start;
+}
+
+.form-error {
+    margin-top: 6px;
+    color: var(--danger);
+    font-size: 12px;
+}
+
+.cards-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.card-item {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    box-shadow: var(--shadow);
+}
+
+.compact-card {
+    cursor: pointer;
+    transition: transform 0.15s ease, border-color 0.15s ease;
+}
+
+.compact-card:hover {
+    transform: translateY(-1px);
+    border-color: var(--primary);
+}
+
+.card-top-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+}
+
+.card-top-row h3 {
+    font-size: 16px;
+    line-height: 1.15;
+    color: var(--text);
+}
+
+.due-badge {
+    display: inline-block;
+    padding: 4px 8px;
+    border-radius: 999px;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.2px;
+}
+
+.due-none {
+    background: rgba(148, 163, 184, 0.18);
+    color: var(--muted);
+}
+
+.due-overdue {
+    background: var(--danger-bg);
+    color: var(--danger);
+}
+
+.due-today {
+    background: var(--warning-bg);
+    color: var(--warning);
+}
+
+.due-soon {
+    background: var(--info-bg);
+    color: var(--info);
+}
+
+.due-later {
+    background: var(--success-bg);
+    color: var(--success);
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/list-details/list-details.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/list-details/list-details.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ListDetails } from './list-details';
+
+describe('ListDetails', () => {
+  let component: ListDetails;
+  let fixture: ComponentFixture<ListDetails>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ListDetails]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ListDetails);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/list-details/list-details.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/list-details/list-details.ts
@@ -1,0 +1,166 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { BoardListModel } from '../../core/models/board-list.model';
+import { CardItemModel } from '../../core/models/card-item.model';
+import { Lists as ListsService } from '../../core/services/lists';
+import { Cards as CardsService } from '../../core/services/cards';
+
+@Component({
+  selector: 'app-list-details',
+  imports: [CommonModule, RouterLink, FormsModule],
+  templateUrl: './list-details.html',
+  styleUrl: './list-details.scss',
+})
+export class ListDetails implements OnInit {
+  list: BoardListModel | null = null;
+  cards: CardItemModel[] = [];
+  isLoading = true;
+  errorMessage = '';
+
+  newCardTitle = '';
+  newCardDescription = '';
+  newCardDueDate = '';
+  creatingCard = false;
+  createCardError = '';
+
+  readonly minDate = this.getTodayAsInputDate();
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private listsService: ListsService,
+    private cardsService: CardsService
+  ) { }
+
+  ngOnInit(): void {
+    const listId = this.route.snapshot.paramMap.get('listId');
+
+    if (!listId) {
+      this.errorMessage = 'List id is missing.';
+      this.isLoading = false;
+      return;
+    }
+
+    this.loadListDetails(listId);
+  }
+
+  private getTodayAsInputDate(): string {
+    const now = new Date();
+    const offset = now.getTimezoneOffset();
+    return new Date(now.getTime() - offset * 60000).toISOString().split('T')[0];
+  }
+
+  getDueDateStatus(card: CardItemModel): 'none' | 'overdue' | 'today' | 'soon' | 'later' {
+    if (!card.dueDateUtc) {
+      return 'none';
+    }
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const dueDate = new Date(card.dueDateUtc);
+    dueDate.setHours(0, 0, 0, 0);
+
+    const diffDays = Math.floor((dueDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+
+    if (diffDays < 0) return 'overdue';
+    if (diffDays === 0) return 'today';
+    if (diffDays <= 7) return 'soon';
+    return 'later';
+  }
+
+  private sortCardsByDueDate(cards: CardItemModel[]): CardItemModel[] {
+    return [...cards].sort((a, b) => {
+      const aDue = a.dueDateUtc ? new Date(a.dueDateUtc).getTime() : Number.MAX_SAFE_INTEGER;
+      const bDue = b.dueDateUtc ? new Date(b.dueDateUtc).getTime() : Number.MAX_SAFE_INTEGER;
+
+      if (aDue !== bDue) {
+        return aDue - bDue;
+      }
+
+      return a.position - b.position;
+    });
+  }
+
+  private loadListDetails(listId: string): void {
+    this.isLoading = true;
+    this.errorMessage = '';
+
+    this.listsService.getListById(listId).subscribe({
+      next: (list) => {
+        this.list = list;
+
+        this.cardsService.getCardsByList(listId).subscribe({
+          next: (cards) => {
+            this.cards = this.sortCardsByDueDate(cards);
+            this.isLoading = false;
+          },
+          error: () => {
+            this.errorMessage = 'Failed to load cards for this list.';
+            this.isLoading = false;
+          }
+        });
+      },
+      error: () => {
+        this.errorMessage = 'Failed to load list details.';
+        this.isLoading = false;
+      }
+    });
+  }
+
+  createCard(): void {
+    const listId = this.list?.id;
+    const trimmedTitle = this.newCardTitle.trim();
+    const trimmedDescription = this.newCardDescription.trim();
+
+    this.createCardError = '';
+
+    if (!listId) {
+      this.createCardError = 'List not found.';
+      return;
+    }
+
+    if (!trimmedTitle) {
+      this.createCardError = 'Card title is required.';
+      return;
+    }
+
+    if (this.newCardDueDate && this.newCardDueDate < this.minDate) {
+      this.createCardError = 'Due date cannot be in the past.';
+      return;
+    }
+
+    this.creatingCard = true;
+
+    this.cardsService.createCard(listId, {
+      title: trimmedTitle,
+      description: trimmedDescription || null,
+      dueDateUtc: this.newCardDueDate ? new Date(this.newCardDueDate).toISOString() : null
+    }).subscribe({
+      next: () => {
+        this.newCardTitle = '';
+        this.newCardDescription = '';
+        this.newCardDueDate = '';
+        this.creatingCard = false;
+        this.loadListDetails(listId);
+      },
+      error: () => {
+        this.createCardError = 'Failed to create card.';
+        this.creatingCard = false;
+      }
+    });
+  }
+
+  openCard(cardId: string): void {
+    const boardId = this.route.snapshot.paramMap.get('boardId');
+    const listId = this.list?.id;
+
+    if (!boardId || !listId) {
+      return;
+    }
+
+    this.router.navigate(['/boards', boardId, 'lists', listId, 'cards', cardId]);
+  }
+}

--- a/SmartTasksAPI/smarttasks-frontend/src/styles.scss
+++ b/SmartTasksAPI/smarttasks-frontend/src/styles.scss
@@ -1,1 +1,110 @@
-/* You can add global styles to this file, and also import other style files */
+:root {
+    --bg-1: #0f172a;
+    --bg-2: #1e293b;
+    --panel: #111827;
+    --panel-soft: rgba(15, 23, 42, 0.88);
+    --panel-deep: #0b1220;
+    --border: #1f2937;
+    --border-soft: #334155;
+    --text: #f8fafc;
+    --muted: #cbd5e1;
+    --muted-2: #94a3b8;
+    --primary: #38bdf8;
+    --primary-dark: #082f49;
+    --danger: #fecaca;
+    --danger-bg: rgba(239, 68, 68, 0.18);
+    --warning: #fdba74;
+    --warning-bg: rgba(249, 115, 22, 0.18);
+    --success: #bbf7d0;
+    --success-bg: rgba(34, 197, 94, 0.18);
+    --info: #bae6fd;
+    --info-bg: rgba(56, 189, 248, 0.18);
+    --shadow: 0 8px 18px rgba(0, 0, 0, 0.2);
+    --radius-lg: 12px;
+    --radius-md: 8px;
+    --radius-sm: 6px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+    min-height: 100%;
+}
+
+body {
+    font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    font-size: 13px;
+    line-height: 1.4;
+    color: var(--text);
+    background: linear-gradient(135deg, var(--bg-1), var(--bg-2));
+}
+
+h1,
+h2,
+h3,
+p {
+    margin: 0;
+}
+
+button,
+input,
+textarea,
+select {
+    font: inherit;
+}
+
+button {
+    border: none;
+    border-radius: var(--radius-md);
+    padding: 8px 12px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    background: var(--primary);
+    color: var(--primary-dark);
+}
+
+button:hover {
+    opacity: 0.96;
+}
+
+button:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+}
+
+input,
+textarea,
+select {
+    width: 100%;
+    background: var(--panel);
+    border: 1px solid var(--border-soft);
+    border-radius: var(--radius-md);
+    padding: 8px 10px;
+    color: var(--text);
+    font-size: 13px;
+}
+
+input::placeholder,
+textarea::placeholder {
+    color: var(--muted-2);
+}
+
+textarea {
+    resize: vertical;
+    min-height: 72px;
+}
+
+a {
+    color: var(--primary);
+    text-decoration: none;
+}
+
+a:hover {
+    opacity: 0.95;
+}


### PR DESCRIPTION
Implemented the main frontend workflow for boards, cards, and task management.

## What was added
- Kanban-style board details page
- Fixed workflow columns: Backlog, Ready, In progress, In review, Done
- New card creation flow with dedicated page
- Card details page with:
  - edit card
  - delete card
  - move card between columns
  - comments
  - assignees
- Board members management
- Frontend access control so only owners/members can view a board

## Notes
- New cards are created in Backlog by default
- Card editing and workflow changes are handled from the Card Details page
- Board view shows due dates and assigned members

Closes #7 
Closes #28 