### PR TITLE
feat: Add API integration and repository tests (#34)

### DIFF
--- a/SmartTasksAPI/SmartTasksAPI.Tests/Integration/ApiIntegrationTests.cs
+++ b/SmartTasksAPI/SmartTasksAPI.Tests/Integration/ApiIntegrationTests.cs
@@ -1,0 +1,300 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace SmartTasksAPI.Tests.Integration;
+
+public class ApiIntegrationTests
+{
+    [Fact]
+    public async Task FullWorkflow_ShouldCreateAndFetchEntitiesAcrossAllControllers()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var ownerId = await CreateUserAsync(client, "Owner One", "owner.integration@example.com");
+
+        var createBoardResponse = await client.PostAsJsonAsync("/api/boards", new
+        {
+            name = "Integration Board",
+            description = "Board for integration testing",
+            ownerId
+        });
+
+        Assert.Equal(HttpStatusCode.Created, createBoardResponse.StatusCode);
+        var boardId = await ReadIdAsync(createBoardResponse);
+
+        var secondUserId = await CreateUserAsync(client, "Member One", "member.integration@example.com");
+
+        var addMemberResponse = await client.PostAsJsonAsync($"/api/boards/{boardId}/members", new
+        {
+            userId = secondUserId
+        });
+
+        Assert.Equal(HttpStatusCode.NoContent, addMemberResponse.StatusCode);
+
+        var createListResponse = await client.PostAsJsonAsync($"/api/boards/{boardId}/lists", new
+        {
+            name = "To Do"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, createListResponse.StatusCode);
+        var listId = await ReadIdAsync(createListResponse);
+
+        var createCardResponse = await client.PostAsJsonAsync($"/api/lists/{listId}/cards", new
+        {
+            title = "Implement Task 4",
+            description = "Add integration tests",
+            dueDateUtc = DateTime.UtcNow.AddDays(2)
+        });
+
+        Assert.Equal(HttpStatusCode.Created, createCardResponse.StatusCode);
+        var cardId = await ReadIdAsync(createCardResponse);
+
+        var assignResponse = await client.PostAsync($"/api/cards/{cardId}/assignments/{secondUserId}", content: null);
+        Assert.Equal(HttpStatusCode.NoContent, assignResponse.StatusCode);
+
+        var createCommentResponse = await client.PostAsJsonAsync($"/api/cards/{cardId}/comments", new
+        {
+            authorId = secondUserId,
+            message = "Looks good"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, createCommentResponse.StatusCode);
+
+        var boardByIdResponse = await client.GetAsync($"/api/boards/{boardId}");
+        Assert.Equal(HttpStatusCode.OK, boardByIdResponse.StatusCode);
+
+        var boardListsResponse = await client.GetAsync($"/api/boards/{boardId}/lists");
+        Assert.Equal(HttpStatusCode.OK, boardListsResponse.StatusCode);
+
+        var listCardsResponse = await client.GetAsync($"/api/lists/{listId}/cards");
+        Assert.Equal(HttpStatusCode.OK, listCardsResponse.StatusCode);
+
+        var cardCommentsResponse = await client.GetAsync($"/api/cards/{cardId}/comments");
+        Assert.Equal(HttpStatusCode.OK, cardCommentsResponse.StatusCode);
+
+        var commentsJson = await cardCommentsResponse.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(JsonValueKind.Array, commentsJson.ValueKind);
+        Assert.True(commentsJson.GetArrayLength() >= 1);
+    }
+
+    [Fact]
+    public async Task CreateBoard_WithMissingOwner_ShouldReturnNotFound()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/boards", new
+        {
+            name = "Orphan Board",
+            description = "No owner",
+            ownerId = Guid.NewGuid()
+        });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateUser_WithDuplicateEmail_ShouldReturnConflict()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var first = await client.PostAsJsonAsync("/api/users", new
+        {
+            fullName = "Duplicate User",
+            email = "duplicate.integration@example.com"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+
+        var second = await client.PostAsJsonAsync("/api/users", new
+        {
+            fullName = "Duplicate User 2",
+            email = "duplicate.integration@example.com"
+        });
+
+        Assert.Equal(HttpStatusCode.Conflict, second.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddMember_Twice_ShouldReturnConflictOnSecondAttempt()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var ownerId = await CreateUserAsync(client, "Owner Two", "owner2.integration@example.com");
+        var memberId = await CreateUserAsync(client, "Member Two", "member2.integration@example.com");
+
+        var boardResponse = await client.PostAsJsonAsync("/api/boards", new
+        {
+            name = "Members Board",
+            description = "Board members",
+            ownerId
+        });
+
+        var boardId = await ReadIdAsync(boardResponse);
+
+        var firstAdd = await client.PostAsJsonAsync($"/api/boards/{boardId}/members", new
+        {
+            userId = memberId
+        });
+
+        Assert.Equal(HttpStatusCode.NoContent, firstAdd.StatusCode);
+
+        var secondAdd = await client.PostAsJsonAsync($"/api/boards/{boardId}/members", new
+        {
+            userId = memberId
+        });
+
+        Assert.Equal(HttpStatusCode.Conflict, secondAdd.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetLists_ForUnknownBoard_ShouldReturnNotFound()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var response = await client.GetAsync($"/api/boards/{Guid.NewGuid()}/lists");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MoveCard_ToMissingList_ShouldReturnNotFound()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var ownerId = await CreateUserAsync(client, "Owner Three", "owner3.integration@example.com");
+
+        var boardResponse = await client.PostAsJsonAsync("/api/boards", new
+        {
+            name = "Move Board",
+            description = "Move cards",
+            ownerId
+        });
+
+        var boardId = await ReadIdAsync(boardResponse);
+
+        var listResponse = await client.PostAsJsonAsync($"/api/boards/{boardId}/lists", new
+        {
+            name = "Doing"
+        });
+
+        var listId = await ReadIdAsync(listResponse);
+
+        var cardResponse = await client.PostAsJsonAsync($"/api/lists/{listId}/cards", new
+        {
+            title = "Card to move",
+            description = "Move me"
+        });
+
+        var cardId = await ReadIdAsync(cardResponse);
+
+        var moveResponse = await client.PatchAsJsonAsync($"/api/cards/{cardId}/move", new
+        {
+            targetListId = Guid.NewGuid(),
+            targetPosition = 1
+        });
+
+        Assert.Equal(HttpStatusCode.NotFound, moveResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task AssignCard_ToMissingUser_ShouldReturnNotFound()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var ownerId = await CreateUserAsync(client, "Owner Four", "owner4.integration@example.com");
+
+        var boardResponse = await client.PostAsJsonAsync("/api/boards", new
+        {
+            name = "Assign Board",
+            description = "Card assignment",
+            ownerId
+        });
+
+        var boardId = await ReadIdAsync(boardResponse);
+
+        var listResponse = await client.PostAsJsonAsync($"/api/boards/{boardId}/lists", new
+        {
+            name = "Done"
+        });
+
+        var listId = await ReadIdAsync(listResponse);
+
+        var cardResponse = await client.PostAsJsonAsync($"/api/lists/{listId}/cards", new
+        {
+            title = "Card",
+            description = "Assign me"
+        });
+
+        var cardId = await ReadIdAsync(cardResponse);
+
+        var assignResponse = await client.PostAsync($"/api/cards/{cardId}/assignments/{Guid.NewGuid()}", content: null);
+
+        Assert.Equal(HttpStatusCode.NotFound, assignResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task DeleteCard_ThenGetById_ShouldReturnNotFound()
+    {
+        using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var ownerId = await CreateUserAsync(client, "Owner Five", "owner5.integration@example.com");
+
+        var boardResponse = await client.PostAsJsonAsync("/api/boards", new
+        {
+            name = "Delete Board",
+            description = "Delete flow",
+            ownerId
+        });
+
+        var boardId = await ReadIdAsync(boardResponse);
+
+        var listResponse = await client.PostAsJsonAsync($"/api/boards/{boardId}/lists", new
+        {
+            name = "Archive"
+        });
+
+        var listId = await ReadIdAsync(listResponse);
+
+        var cardResponse = await client.PostAsJsonAsync($"/api/lists/{listId}/cards", new
+        {
+            title = "Delete me",
+            description = "Cleanup"
+        });
+
+        var cardId = await ReadIdAsync(cardResponse);
+
+        var deleteResponse = await client.DeleteAsync($"/api/cards/{cardId}");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        var getDeletedResponse = await client.GetAsync($"/api/cards/{cardId}");
+        Assert.Equal(HttpStatusCode.NotFound, getDeletedResponse.StatusCode);
+    }
+
+    private static async Task<Guid> CreateUserAsync(HttpClient client, string fullName, string email)
+    {
+        var response = await client.PostAsJsonAsync("/api/users", new
+        {
+            fullName,
+            email
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        return await ReadIdAsync(response);
+    }
+
+    private static async Task<Guid> ReadIdAsync(HttpResponseMessage response)
+    {
+        var payload = await response.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.True(payload.TryGetProperty("id", out var idProperty));
+        return idProperty.GetGuid();
+    }
+}

--- a/SmartTasksAPI/SmartTasksAPI.Tests/Integration/TestWebApplicationFactory.cs
+++ b/SmartTasksAPI/SmartTasksAPI.Tests/Integration/TestWebApplicationFactory.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using SmartTasksAPI.Models.Data;
+
+namespace SmartTasksAPI.Tests.Integration;
+
+public class TestWebApplicationFactory : WebApplicationFactory<SmartTasksAPI.Program>
+{
+    private readonly string _databaseName = $"smarttasks-tests-{Guid.NewGuid()}";
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureServices(services =>
+        {
+            var dbContextDescriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+
+            if (dbContextDescriptor is not null)
+            {
+                services.Remove(dbContextDescriptor);
+            }
+
+            services.AddDbContext<ApplicationDbContext>(options =>
+            {
+                options.UseInMemoryDatabase(_databaseName);
+            });
+        });
+    }
+}

--- a/SmartTasksAPI/SmartTasksAPI.Tests/Repository/RepositoryTestDatabase.cs
+++ b/SmartTasksAPI/SmartTasksAPI.Tests/Repository/RepositoryTestDatabase.cs
@@ -1,0 +1,31 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using SmartTasksAPI.Models.Data;
+
+namespace SmartTasksAPI.Tests.Repository;
+
+public sealed class RepositoryTestDatabase : IDisposable
+{
+    private readonly SqliteConnection _connection;
+
+    public RepositoryTestDatabase()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+        ContextOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        using var context = CreateContext();
+        context.Database.EnsureCreated();
+    }
+
+    public DbContextOptions<ApplicationDbContext> ContextOptions { get; }
+
+    public ApplicationDbContext CreateContext() => new(ContextOptions);
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+    }
+}

--- a/SmartTasksAPI/SmartTasksAPI.Tests/Repository/RepositoryTests.cs
+++ b/SmartTasksAPI/SmartTasksAPI.Tests/Repository/RepositoryTests.cs
@@ -1,0 +1,614 @@
+using Microsoft.EntityFrameworkCore;
+using SmartTasksAPI.Models;
+using SmartTasksAPI.Models.Enums;
+using SmartTasksAPI.Repositories;
+
+namespace SmartTasksAPI.Tests.Repository;
+
+public class RepositoryTests
+{
+    [Fact]
+    public async Task UserRepository_ShouldPersistAndQueryByEmail()
+    {
+        using var database = new RepositoryTestDatabase();
+        await using var context = database.CreateContext();
+        var repository = new UserRepository(context);
+
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Alice Example",
+            Email = "alice@example.com"
+        };
+
+        var saved = await repository.AddAsync(user);
+
+        Assert.Equal(user.Id, saved.Id);
+
+        var allUsers = await repository.GetAllAsync();
+        Assert.Single(allUsers);
+        Assert.Equal("alice@example.com", allUsers[0].Email);
+
+        var foundByEmail = await repository.GetByEmailAsync("alice@example.com");
+        Assert.NotNull(foundByEmail);
+        Assert.Equal(user.Id, foundByEmail!.Id);
+    }
+
+    [Fact]
+    public async Task UserRepository_ShouldEnforceUniqueEmail()
+    {
+        using var database = new RepositoryTestDatabase();
+        await using var context = database.CreateContext();
+        var repository = new UserRepository(context);
+
+        await repository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Alice Example",
+            Email = "duplicate@example.com"
+        });
+
+        var secondUser = new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Bob Example",
+            Email = "duplicate@example.com"
+        };
+
+        await Assert.ThrowsAsync<DbUpdateException>(() => repository.AddAsync(secondUser));
+    }
+
+    [Fact]
+    public async Task BoardRepository_ShouldLoadOwnerMembersAndOrderedLists()
+    {
+        using var database = new RepositoryTestDatabase();
+        await using var context = database.CreateContext();
+        var userRepository = new UserRepository(context);
+        var boardRepository = new BoardRepository(context);
+        var listRepository = new ListRepository(context);
+
+        var owner = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Owner",
+            Email = "owner@example.com"
+        });
+
+        var member = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Member",
+            Email = "member@example.com"
+        });
+
+        var board = await boardRepository.AddAsync(new Board
+        {
+            Id = Guid.NewGuid(),
+            Name = "Board",
+            Description = "Board description",
+            OwnerId = owner.Id
+        });
+
+        await boardRepository.AddMemberAsync(new BoardMember
+        {
+            BoardId = board.Id,
+            UserId = owner.Id,
+            Role = BoardRole.Owner
+        });
+
+        await boardRepository.AddMemberAsync(new BoardMember
+        {
+            BoardId = board.Id,
+            UserId = member.Id,
+            Role = BoardRole.Member
+        });
+
+        await context.Lists.AddRangeAsync(
+            new BoardList
+            {
+                Id = Guid.NewGuid(),
+                BoardId = board.Id,
+                Name = "Second",
+                Position = 2
+            },
+            new BoardList
+            {
+                Id = Guid.NewGuid(),
+                BoardId = board.Id,
+                Name = "First",
+                Position = 1
+            });
+
+        await context.SaveChangesAsync();
+
+        var loadedBoard = await boardRepository.GetByIdAsync(board.Id);
+
+        Assert.NotNull(loadedBoard);
+        Assert.Equal(owner.Id, loadedBoard!.OwnerId);
+        Assert.NotNull(loadedBoard.Owner);
+        Assert.Equal(owner.Email, loadedBoard.Owner!.Email);
+        Assert.Equal(2, loadedBoard.Members.Count);
+        Assert.Equal(2, loadedBoard.Lists.Count);
+        Assert.Contains(loadedBoard.Lists, x => x.Name == "First");
+        Assert.Contains(loadedBoard.Lists, x => x.Name == "Second");
+
+        var orderedLists = await listRepository.GetByBoardIdAsync(board.Id);
+        Assert.Equal(new[] { "First", "Second" }, orderedLists.Select(x => x.Name).ToArray());
+    }
+
+    [Fact]
+    public async Task BoardRepository_ShouldTrackMembersAndPreventDuplicateMembership()
+    {
+        using var database = new RepositoryTestDatabase();
+        await using var context = database.CreateContext();
+        var userRepository = new UserRepository(context);
+        var boardRepository = new BoardRepository(context);
+
+        var owner = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Owner",
+            Email = "owner2@example.com"
+        });
+
+        var board = await boardRepository.AddAsync(new Board
+        {
+            Id = Guid.NewGuid(),
+            Name = "Team Board",
+            OwnerId = owner.Id
+        });
+
+        var member = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Member",
+            Email = "member2@example.com"
+        });
+
+        await boardRepository.AddMemberAsync(new BoardMember
+        {
+            BoardId = board.Id,
+            UserId = member.Id,
+            Role = BoardRole.Member
+        });
+
+        Assert.True(await boardRepository.MemberExistsAsync(board.Id, member.Id));
+
+        var storedMember = await boardRepository.GetMemberAsync(board.Id, member.Id);
+        Assert.NotNull(storedMember);
+        Assert.Equal(BoardRole.Member, storedMember!.Role);
+
+        await boardRepository.RemoveMemberAsync(storedMember);
+        Assert.False(await boardRepository.MemberExistsAsync(board.Id, member.Id));
+    }
+
+    [Fact]
+    public async Task BoardRepository_ShouldEnforceCompositeMemberKey()
+    {
+        using var database = new RepositoryTestDatabase();
+        await using var context = database.CreateContext();
+        var userRepository = new UserRepository(context);
+        var boardRepository = new BoardRepository(context);
+
+        var owner = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Owner",
+            Email = "owner3@example.com"
+        });
+
+        var board = await boardRepository.AddAsync(new Board
+        {
+            Id = Guid.NewGuid(),
+            Name = "Duplicate Member Board",
+            OwnerId = owner.Id
+        });
+
+        var member = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Member",
+            Email = "member3@example.com"
+        });
+
+        await boardRepository.AddMemberAsync(new BoardMember
+        {
+            BoardId = board.Id,
+            UserId = member.Id,
+            Role = BoardRole.Member
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => boardRepository.AddMemberAsync(new BoardMember
+        {
+            BoardId = board.Id,
+            UserId = member.Id,
+            Role = BoardRole.Member
+        }));
+    }
+
+    [Fact]
+    public async Task ListRepository_ShouldOrderByPositionAndIncrementNextPosition()
+    {
+        using var database = new RepositoryTestDatabase();
+        await using var context = database.CreateContext();
+        var userRepository = new UserRepository(context);
+        var boardRepository = new BoardRepository(context);
+        var listRepository = new ListRepository(context);
+
+        var owner = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Owner",
+            Email = "owner4@example.com"
+        });
+
+        var board = await boardRepository.AddAsync(new Board
+        {
+            Id = Guid.NewGuid(),
+            Name = "List Board",
+            OwnerId = owner.Id
+        });
+
+        var firstPosition = await listRepository.GetNextPositionAsync(board.Id);
+        Assert.Equal(1, firstPosition);
+
+        await listRepository.AddAsync(new BoardList
+        {
+            Id = Guid.NewGuid(),
+            BoardId = board.Id,
+            Name = "Second",
+            Position = 2
+        });
+
+        await listRepository.AddAsync(new BoardList
+        {
+            Id = Guid.NewGuid(),
+            BoardId = board.Id,
+            Name = "First",
+            Position = 1
+        });
+
+        var lists = await listRepository.GetByBoardIdAsync(board.Id);
+        Assert.Equal(new[] { "First", "Second" }, lists.Select(x => x.Name).ToArray());
+        Assert.Equal(3, await listRepository.GetNextPositionAsync(board.Id));
+    }
+
+    [Fact]
+    public async Task ListRepository_ShouldUpdateAndDelete()
+    {
+        using var database = new RepositoryTestDatabase();
+        await using var context = database.CreateContext();
+        var userRepository = new UserRepository(context);
+        var boardRepository = new BoardRepository(context);
+        var listRepository = new ListRepository(context);
+
+        var owner = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Owner",
+            Email = "owner5@example.com"
+        });
+
+        var board = await boardRepository.AddAsync(new Board
+        {
+            Id = Guid.NewGuid(),
+            Name = "Update Board",
+            OwnerId = owner.Id
+        });
+
+        var list = await listRepository.AddAsync(new BoardList
+        {
+            Id = Guid.NewGuid(),
+            BoardId = board.Id,
+            Name = "Todo",
+            Position = 1
+        });
+
+        list.Name = "Doing";
+        list.Position = 2;
+        await listRepository.UpdateAsync(list);
+
+        var loaded = await listRepository.GetByIdAsync(list.Id);
+        Assert.NotNull(loaded);
+        Assert.Equal("Doing", loaded!.Name);
+        Assert.Equal(2, loaded.Position);
+
+        await listRepository.DeleteAsync(loaded);
+        Assert.Null(await listRepository.GetByIdAsync(list.Id));
+    }
+
+    [Fact]
+    public async Task CardRepository_ShouldOrderCardsAndLoadAssignmentsAndComments()
+    {
+        using var database = new RepositoryTestDatabase();
+        await using var context = database.CreateContext();
+        var userRepository = new UserRepository(context);
+        var boardRepository = new BoardRepository(context);
+        var listRepository = new ListRepository(context);
+        var cardRepository = new CardRepository(context);
+        var commentRepository = new CommentRepository(context);
+
+        var owner = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Owner",
+            Email = "owner6@example.com"
+        });
+
+        var assignee = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Assignee",
+            Email = "assignee6@example.com"
+        });
+
+        var board = await boardRepository.AddAsync(new Board
+        {
+            Id = Guid.NewGuid(),
+            Name = "Card Board",
+            OwnerId = owner.Id
+        });
+
+        var list = await listRepository.AddAsync(new BoardList
+        {
+            Id = Guid.NewGuid(),
+            BoardId = board.Id,
+            Name = "Backlog",
+            Position = 1
+        });
+
+        await cardRepository.AddAsync(new CardItem
+        {
+            Id = Guid.NewGuid(),
+            ListId = list.Id,
+            Title = "Second",
+            Position = 2
+        });
+
+        var firstCard = await cardRepository.AddAsync(new CardItem
+        {
+            Id = Guid.NewGuid(),
+            ListId = list.Id,
+            Title = "First",
+            Position = 1
+        });
+
+        await cardRepository.AddAssignmentAsync(new CardAssignment
+        {
+            CardId = firstCard.Id,
+            UserId = assignee.Id
+        });
+
+        await commentRepository.AddAsync(new CardComment
+        {
+            Id = Guid.NewGuid(),
+            CardId = firstCard.Id,
+            AuthorId = assignee.Id,
+            Message = "Second comment",
+            CreatedAtUtc = DateTime.UtcNow.AddMinutes(1)
+        });
+
+        await commentRepository.AddAsync(new CardComment
+        {
+            Id = Guid.NewGuid(),
+            CardId = firstCard.Id,
+            AuthorId = assignee.Id,
+            Message = "First comment",
+            CreatedAtUtc = DateTime.UtcNow
+        });
+
+        var cards = await cardRepository.GetByListIdAsync(list.Id);
+        Assert.Equal(new[] { "First", "Second" }, cards.Select(x => x.Title).ToArray());
+
+        var loadedCard = await cardRepository.GetByIdAsync(firstCard.Id);
+        Assert.NotNull(loadedCard);
+        Assert.Single(loadedCard!.Assignments);
+        Assert.Equal(assignee.Id, loadedCard.Assignments.First().UserId);
+        Assert.Equal(2, loadedCard.Comments.Count);
+        Assert.All(loadedCard.Comments, comment => Assert.NotNull(comment.Author));
+
+        var orderedComments = await commentRepository.GetByCardIdAsync(firstCard.Id);
+        Assert.Equal(new[] { "First comment", "Second comment" }, orderedComments.Select(x => x.Message).ToArray());
+    }
+
+    [Fact]
+    public async Task CardRepository_ShouldIncrementPositionAndManageAssignments()
+    {
+        using var database = new RepositoryTestDatabase();
+        await using var context = database.CreateContext();
+        var userRepository = new UserRepository(context);
+        var boardRepository = new BoardRepository(context);
+        var listRepository = new ListRepository(context);
+        var cardRepository = new CardRepository(context);
+
+        var owner = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Owner",
+            Email = "owner7@example.com"
+        });
+
+        var assignee = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Assignee",
+            Email = "assignee7@example.com"
+        });
+
+        var board = await boardRepository.AddAsync(new Board
+        {
+            Id = Guid.NewGuid(),
+            Name = "Assignment Board",
+            OwnerId = owner.Id
+        });
+
+        var list = await listRepository.AddAsync(new BoardList
+        {
+            Id = Guid.NewGuid(),
+            BoardId = board.Id,
+            Name = "Doing",
+            Position = 1
+        });
+
+        Assert.Equal(1, await cardRepository.GetNextPositionAsync(list.Id));
+
+        var card = await cardRepository.AddAsync(new CardItem
+        {
+            Id = Guid.NewGuid(),
+            ListId = list.Id,
+            Title = "Task",
+            Position = 1
+        });
+
+        Assert.Equal(2, await cardRepository.GetNextPositionAsync(list.Id));
+
+        var assignment = new CardAssignment
+        {
+            CardId = card.Id,
+            UserId = assignee.Id
+        };
+
+        await cardRepository.AddAssignmentAsync(assignment);
+        var loadedAssignment = await cardRepository.GetAssignmentAsync(card.Id, assignee.Id);
+        Assert.NotNull(loadedAssignment);
+
+        await cardRepository.RemoveAssignmentAsync(loadedAssignment!);
+        Assert.Null(await cardRepository.GetAssignmentAsync(card.Id, assignee.Id));
+    }
+
+    [Fact]
+    public async Task CardRepository_ShouldEnforceCompositeAssignmentKey()
+    {
+        using var database = new RepositoryTestDatabase();
+        await using var context = database.CreateContext();
+        var userRepository = new UserRepository(context);
+        var boardRepository = new BoardRepository(context);
+        var listRepository = new ListRepository(context);
+        var cardRepository = new CardRepository(context);
+
+        var owner = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Owner",
+            Email = "owner8@example.com"
+        });
+
+        var assignee = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Assignee",
+            Email = "assignee8@example.com"
+        });
+
+        var board = await boardRepository.AddAsync(new Board
+        {
+            Id = Guid.NewGuid(),
+            Name = "Composite Board",
+            OwnerId = owner.Id
+        });
+
+        var list = await listRepository.AddAsync(new BoardList
+        {
+            Id = Guid.NewGuid(),
+            BoardId = board.Id,
+            Name = "Backlog",
+            Position = 1
+        });
+
+        var card = await cardRepository.AddAsync(new CardItem
+        {
+            Id = Guid.NewGuid(),
+            ListId = list.Id,
+            Title = "Task",
+            Position = 1
+        });
+
+        await cardRepository.AddAssignmentAsync(new CardAssignment
+        {
+            CardId = card.Id,
+            UserId = assignee.Id
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => cardRepository.AddAssignmentAsync(new CardAssignment
+        {
+            CardId = card.Id,
+            UserId = assignee.Id
+        }));
+    }
+
+    [Fact]
+    public async Task CommentRepository_ShouldOrderByCreatedAtAndDelete()
+    {
+        using var database = new RepositoryTestDatabase();
+        await using var context = database.CreateContext();
+        var userRepository = new UserRepository(context);
+        var boardRepository = new BoardRepository(context);
+        var listRepository = new ListRepository(context);
+        var cardRepository = new CardRepository(context);
+        var commentRepository = new CommentRepository(context);
+
+        var owner = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Owner",
+            Email = "owner9@example.com"
+        });
+
+        var author = await userRepository.AddAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            FullName = "Author",
+            Email = "author9@example.com"
+        });
+
+        var board = await boardRepository.AddAsync(new Board
+        {
+            Id = Guid.NewGuid(),
+            Name = "Comment Board",
+            OwnerId = owner.Id
+        });
+
+        var list = await listRepository.AddAsync(new BoardList
+        {
+            Id = Guid.NewGuid(),
+            BoardId = board.Id,
+            Name = "Inbox",
+            Position = 1
+        });
+
+        var card = await cardRepository.AddAsync(new CardItem
+        {
+            Id = Guid.NewGuid(),
+            ListId = list.Id,
+            Title = "Task",
+            Position = 1
+        });
+
+        var laterComment = await commentRepository.AddAsync(new CardComment
+        {
+            Id = Guid.NewGuid(),
+            CardId = card.Id,
+            AuthorId = author.Id,
+            Message = "Later",
+            CreatedAtUtc = DateTime.UtcNow.AddMinutes(1)
+        });
+
+        var earlierComment = await commentRepository.AddAsync(new CardComment
+        {
+            Id = Guid.NewGuid(),
+            CardId = card.Id,
+            AuthorId = author.Id,
+            Message = "Earlier",
+            CreatedAtUtc = DateTime.UtcNow
+        });
+
+        var comments = await commentRepository.GetByCardIdAsync(card.Id);
+        Assert.Equal(new[] { "Earlier", "Later" }, comments.Select(x => x.Message).ToArray());
+
+        var loadedComment = await commentRepository.GetByIdAsync(earlierComment.Id);
+        Assert.NotNull(loadedComment);
+        await commentRepository.DeleteAsync(loadedComment!);
+        Assert.Null(await commentRepository.GetByIdAsync(earlierComment.Id));
+        Assert.NotNull(await commentRepository.GetByIdAsync(laterComment.Id));
+    }
+}

--- a/SmartTasksAPI/SmartTasksAPI.Tests/SmartTasksAPI.Tests.csproj
+++ b/SmartTasksAPI/SmartTasksAPI.Tests/SmartTasksAPI.Tests.csproj
@@ -12,6 +12,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/SmartTasksAPI/SmartTasksAPI/Program.cs
+++ b/SmartTasksAPI/SmartTasksAPI/Program.cs
@@ -46,40 +46,43 @@ namespace SmartTasksAPI
 
             // Ensure database is created and migrations are applied on startup.
             // This will run once per environment (the first time the DB is created in the Docker volume).
-            using (var scope = app.Services.CreateScope())
+            if (!app.Environment.IsEnvironment("Testing"))
             {
-                var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
-                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-
-                const int maxRetries = 15;
-                var delay = TimeSpan.FromSeconds(5);
-                for (int attempt = 0; attempt < maxRetries; attempt++)
+                using (var scope = app.Services.CreateScope())
                 {
-                    try
+                    var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+                    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+                    const int maxRetries = 15;
+                    var delay = TimeSpan.FromSeconds(5);
+                    for (int attempt = 0; attempt < maxRetries; attempt++)
                     {
-                        var pending = db.Database.GetPendingMigrations();
-                        if (pending.Any())
+                        try
                         {
-                            db.Database.Migrate();
-                            logger.LogInformation("Applied {Count} pending EF migrations.", pending.Count());
+                            var pending = db.Database.GetPendingMigrations();
+                            if (pending.Any())
+                            {
+                                db.Database.Migrate();
+                                logger.LogInformation("Applied {Count} pending EF migrations.", pending.Count());
+                            }
+                            else
+                            {
+                                // No migrations found - ensure database is created to support dev scenarios without migrations
+                                db.Database.EnsureCreated();
+                                logger.LogInformation("No EF migrations found; ensured database is created.");
+                            }
+                            break;
                         }
-                        else
+                        catch (Exception ex)
                         {
-                            // No migrations found - ensure database is created to support dev scenarios without migrations
-                            db.Database.EnsureCreated();
-                            logger.LogInformation("No EF migrations found; ensured database is created.");
+                            logger.LogWarning(ex, "Database unavailable, retrying in {Delay}s (attempt {Attempt}/{Max})", delay.TotalSeconds, attempt + 1, maxRetries);
+                            if (attempt == maxRetries - 1)
+                            {
+                                logger.LogError(ex, "Failed to apply database migrations after {Max} attempts.", maxRetries);
+                                throw;
+                            }
+                            Thread.Sleep(delay);
                         }
-                        break;
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.LogWarning(ex, "Database unavailable, retrying in {Delay}s (attempt {Attempt}/{Max})", delay.TotalSeconds, attempt + 1, maxRetries);
-                        if (attempt == maxRetries - 1)
-                        {
-                            logger.LogError(ex, "Failed to apply database migrations after {Max} attempts.");
-                            throw;
-                        }
-                        Thread.Sleep(delay);
                     }
                 }
             }
@@ -91,7 +94,10 @@ namespace SmartTasksAPI
                 app.UseSwaggerUI();
             }
 
-            app.UseHttpsRedirection();
+            if (!app.Environment.IsEnvironment("Testing"))
+            {
+                app.UseHttpsRedirection();
+            }
 
             app.UseAuthorization();
 


### PR DESCRIPTION
- Add integration tests for end-to-end API flows across boards, lists, cards, comments, and users
- Add repository tests backed by SQLite in-memory to validate EF relationships, ordering, and unique key behavior
- Add test infrastructure for isolated WebApplicationFactory and SQLite database fixture
- Make Program startup test-friendly in the Testing environment
- Add test packages required for ASP.NET Core integration and EF Core SQLite-backed tests

Closes #34