### PR TITLE
feat: Expand frontend unit tests and add smoke E2E flow (#36)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,43 @@ jobs:
           path: |
             SmartTasksAPI/SmartTasksAPI.Tests/TestResults/CoverageReport
             SmartTasksAPI/SmartTasksAPI.Tests/TestResults/Coverage/coverage.cobertura.xml
+
+  frontend-tests:
+    name: Frontend unit and smoke E2E
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: SmartTasksAPI/smarttasks-frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: SmartTasksAPI/smarttasks-frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Angular unit tests
+        run: npx ng test --watch=false --browsers=ChromeHeadless
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run smoke E2E tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-playwright-artifacts
+          path: |
+            SmartTasksAPI/smarttasks-frontend/playwright-report
+            SmartTasksAPI/smarttasks-frontend/test-results

--- a/SmartTasksAPI/smarttasks-frontend/.gitignore
+++ b/SmartTasksAPI/smarttasks-frontend/.gitignore
@@ -33,6 +33,8 @@ yarn-error.log
 .sass-cache/
 /connect.lock
 /coverage
+/playwright-report
+/test-results
 /libpeerconnection.log
 testem.log
 /typings

--- a/SmartTasksAPI/smarttasks-frontend/angular.json
+++ b/SmartTasksAPI/smarttasks-frontend/angular.json
@@ -94,5 +94,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/SmartTasksAPI/smarttasks-frontend/e2e/auth-smoke.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/e2e/auth-smoke.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Auth smoke flow', () => {
+    test('registers a new user and navigates to boards after login', async ({ page }) => {
+        const timestamp = Date.now();
+        const username = `smoke-user-${timestamp}`;
+        const email = `smoke-${timestamp}@example.com`;
+        const password = 'secret123';
+
+        await page.goto('/register');
+
+        await page.fill('#username', username);
+        await page.fill('#email', email);
+        await page.fill('#password', password);
+        await page.fill('#confirmPassword', password);
+        await page.getByRole('button', { name: 'Register' }).click();
+
+        await expect(page.getByText('Account created successfully.')).toBeVisible();
+        await page.waitForURL('**/login');
+
+        await page.fill('#username', username);
+        await page.fill('#password', password);
+        await page.getByRole('button', { name: 'Login' }).click();
+
+        await expect(page.getByText('Login successful.')).toBeVisible();
+        await page.waitForURL('**/boards');
+        await expect(page.getByRole('heading', { name: 'Boards' })).toBeVisible();
+    });
+});

--- a/SmartTasksAPI/smarttasks-frontend/package-lock.json
+++ b/SmartTasksAPI/smarttasks-frontend/package-lock.json
@@ -22,6 +22,7 @@
         "@angular/build": "^20.3.8",
         "@angular/cli": "^20.3.8",
         "@angular/compiler-cli": "^20.3.0",
+        "@playwright/test": "^1.54.2",
         "@types/jasmine": "~5.1.0",
         "jasmine-core": "~5.9.0",
         "karma": "~6.4.0",
@@ -2961,6 +2962,22 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -7567,6 +7584,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/SmartTasksAPI/smarttasks-frontend/package.json
+++ b/SmartTasksAPI/smarttasks-frontend/package.json
@@ -6,7 +6,9 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed"
   },
   "prettier": {
     "printWidth": 100,
@@ -33,6 +35,7 @@
     "zone.js": "~0.15.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.54.2",
     "@angular/build": "^20.3.8",
     "@angular/cli": "^20.3.8",
     "@angular/compiler-cli": "^20.3.0",

--- a/SmartTasksAPI/smarttasks-frontend/playwright.config.ts
+++ b/SmartTasksAPI/smarttasks-frontend/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+    testDir: './e2e',
+    timeout: 30_000,
+    expect: {
+        timeout: 5_000
+    },
+    fullyParallel: true,
+    retries: 0,
+    reporter: [['list'], ['html', { open: 'never' }]],
+    use: {
+        baseURL: 'http://127.0.0.1:4200',
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure'
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: { ...devices['Desktop Chrome'] }
+        }
+    ],
+    webServer: {
+        command: 'npm run start -- --host 127.0.0.1 --port 4200',
+        url: 'http://127.0.0.1:4200',
+        reuseExistingServer: true,
+        timeout: 120_000
+    }
+});

--- a/SmartTasksAPI/smarttasks-frontend/src/app/app.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/app.spec.ts
@@ -1,10 +1,12 @@
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { App } from './app';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [provideRouter([])]
     }).compileComponents();
   });
 
@@ -14,10 +16,10 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render title', () => {
+  it('should render router outlet', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, smarttasks-frontend');
+    expect(compiled.querySelector('router-outlet')).toBeTruthy();
   });
 });

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/auth.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/auth.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { Auth } from './auth';
 
@@ -6,7 +7,9 @@ describe('Auth', () => {
   let service: Auth;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient()]
+    });
     service = TestBed.inject(Auth);
   });
 

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/boards.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/boards.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { Boards } from './boards';
 
@@ -6,7 +7,9 @@ describe('Boards', () => {
   let service: Boards;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient()]
+    });
     service = TestBed.inject(Boards);
   });
 

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/cards.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/cards.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { Cards } from './cards';
 
@@ -6,7 +7,9 @@ describe('Cards', () => {
   let service: Cards;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient()]
+    });
     service = TestBed.inject(Cards);
   });
 

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/comments.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/comments.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { Comments } from './comments';
 
@@ -6,7 +7,9 @@ describe('Comments', () => {
   let service: Comments;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient()]
+    });
     service = TestBed.inject(Comments);
   });
 

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/lists.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/lists.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { Lists } from './lists';
 
@@ -6,7 +7,9 @@ describe('Lists', () => {
   let service: Lists;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient()]
+    });
     service = TestBed.inject(Lists);
   });
 

--- a/SmartTasksAPI/smarttasks-frontend/src/app/core/services/users.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/core/services/users.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { Users } from './users';
 
@@ -6,7 +7,9 @@ describe('Users', () => {
   let service: Users;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient()]
+    });
     service = TestBed.inject(Users);
   });
 

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/board-details/board-details.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/board-details/board-details.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { ActivatedRoute, provideRouter } from '@angular/router';
 
 import { BoardDetails } from './board-details';
 
@@ -8,9 +10,23 @@ describe('BoardDetails', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [BoardDetails]
+      imports: [BoardDetails],
+      providers: [
+        provideHttpClient(),
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: () => null
+              }
+            }
+          }
+        }
+      ]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(BoardDetails);
     component = fixture.componentInstance;

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/boards/boards.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/boards/boards.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
 import { Boards } from './boards';
 
@@ -8,9 +10,10 @@ describe('Boards', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Boards]
+      imports: [Boards],
+      providers: [provideHttpClient(), provideRouter([])]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(Boards);
     component = fixture.componentInstance;

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/card-details/card-details.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/card-details/card-details.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { ActivatedRoute, provideRouter } from '@angular/router';
 
 import { CardDetails } from './card-details';
 
@@ -8,9 +10,23 @@ describe('CardDetails', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CardDetails]
+      imports: [CardDetails],
+      providers: [
+        provideHttpClient(),
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: () => null
+              }
+            }
+          }
+        }
+      ]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(CardDetails);
     component = fixture.componentInstance;

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/create-card/create-card.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/create-card/create-card.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { ActivatedRoute, provideRouter } from '@angular/router';
 
 import { CreateCard } from './create-card';
 
@@ -8,9 +10,23 @@ describe('CreateCard', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CreateCard]
+      imports: [CreateCard],
+      providers: [
+        provideHttpClient(),
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: () => null
+              }
+            }
+          }
+        }
+      ]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(CreateCard);
     component = fixture.componentInstance;

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/list-details/list-details.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/list-details/list-details.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { ActivatedRoute, provideRouter } from '@angular/router';
 
 import { ListDetails } from './list-details';
 
@@ -8,9 +10,23 @@ describe('ListDetails', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ListDetails]
+      imports: [ListDetails],
+      providers: [
+        provideHttpClient(),
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: () => null
+              }
+            }
+          }
+        }
+      ]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(ListDetails);
     component = fixture.componentInstance;

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/login/login.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/login/login.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
 import { Login } from './login';
 
@@ -8,9 +10,10 @@ describe('Login', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Login]
+      imports: [Login],
+      providers: [provideHttpClient(), provideRouter([])]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(Login);
     component = fixture.componentInstance;

--- a/SmartTasksAPI/smarttasks-frontend/src/app/pages/register/register.spec.ts
+++ b/SmartTasksAPI/smarttasks-frontend/src/app/pages/register/register.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
 
 import { Register } from './register';
 
@@ -8,9 +10,10 @@ describe('Register', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Register]
+      imports: [Register],
+      providers: [provideHttpClient(), provideRouter([])]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(Register);
     component = fixture.componentInstance;

--- a/SmartTasksAPI/smarttasks-frontend/tsconfig.spec.json
+++ b/SmartTasksAPI/smarttasks-frontend/tsconfig.spec.json
@@ -3,6 +3,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "rootDir": "./src",
     "outDir": "./out-tsc/spec",
     "types": [
       "jasmine"


### PR DESCRIPTION
- Replace boilerplate Angular specs with stable component/service test setup
- Add required providers for HttpClient, Router, and ActivatedRoute in unit tests
- Update app spec assertions to match current router-outlet template
- Add Playwright configuration and smoke auth flow (register -> login -> boards)
- Add frontend E2E scripts and ignore generated test artifacts
- Add frontend CI job to run Angular unit tests and Playwright smoke E2E on push/PR

Closes #36